### PR TITLE
feat: make staff optional for exec ed courses

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -73,7 +73,7 @@ const handleCourseEditFail = (errors) => {
 };
 
 const editCourseValidate = (values, props) => {
-  const { targetRun } = props;
+  const { targetRun, registeredFields } = props;
 
   if (!targetRun || targetRun.status === PUBLISHED) {
     return {};
@@ -98,7 +98,10 @@ const editCourseValidate = (values, props) => {
     const { key: targetKey } = targetRun;
     const isSubmittingRun = run.key === targetKey;
     if (isSubmittingRun) {
-      const runRequiredFields = ['transcript_languages', 'staff'];
+      // naive check to deteremine if track is executive education or not
+      const isExecutiveEducation = "prices.executive-education" in registeredFields && registeredFields['prices.executive-education'].count;
+
+      const runRequiredFields = isExecutiveEducation ? ['transcript_languages'] : ['transcript_languages', 'staff'];
       const runErrors = {};
       runRequiredFields.forEach((fieldName) => {
         const value = run[fieldName];

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -99,7 +99,9 @@ const editCourseValidate = (values, props) => {
     const isSubmittingRun = run.key === targetKey;
     if (isSubmittingRun) {
       // naive check to deteremine if track is executive education or not
-      const isExecutiveEducation = "prices.executive-education" in registeredFields && registeredFields['prices.executive-education'].count;
+      const isExecutiveEducation = registeredFields
+        && registeredFields['prices.executive-education']
+        && registeredFields['prices.executive-education'].count;
 
       const runRequiredFields = isExecutiveEducation ? ['transcript_languages'] : ['transcript_languages', 'staff'];
       const runErrors = {};

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -218,4 +218,34 @@ describe('editCourseValidate', () => {
     };
     expect(editCourseValidate(values, { targetRun: unpublishedTargetRun })).toEqual(expectedErrors);
   });
+  it('returns no error on submitting executive education course runs with missing staff', () => {
+    const values = {
+      short_description: 'Short',
+      full_description: 'Full',
+      outcome: 'Outcome',
+      imageSrc: 'base64;encodedimage',
+      course_runs: [
+        {
+          key: 'NonSubmittingTestRun',
+        },
+        {
+          key: 'TestRun',
+          transcript_languages: [
+            {
+              dummy_field: 'Transcript languages dummy field',
+            },
+          ],
+          staff: [],
+        },
+      ],
+    };
+    expect(editCourseValidate(values, {
+      targetRun: unpublishedTargetRun,
+      registeredFields: {
+        'prices.executive-education': {
+          count: 1,
+        },
+      },
+    })).toEqual({});
+  });
 });


### PR DESCRIPTION
## Description:
This PR will add a check to make `staff` field optional for `Executive Education` courses. 

## Linked Ticket:
[PROD-2685](https://openedx.atlassian.net/browse/PROD-2685)

## Logic:
Validation function only receive track `type`'s uuid (as in disco) under `targetRun` prop therefore I can't seem to find an easier way to determine track type name in validation function. One option is to take `mode` from `entitlement` prop but that only works if correct track is set at creation (e.g. not if we are editing from Audit to Executive Education). Hence, this `prices.<track-slug>` field only have a positive count when desired track (i.e. executive education) is selected. However, if there are better options available, we should opt that or make sure that the underlying assumption is correct before merging this PR. 


## TODO:
- [x] Add unit tests
- [ ] Improve exec ed track check
- [x] Get owner's review
- [ ] The name of `Executive Education` track may be renamed to `Executive Program`