### PR TITLE
feat: updating table to data table

### DIFF
--- a/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
+++ b/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
@@ -127,24 +127,28 @@ exports[`CourseTable displays table and button when not blacklisted 1`] = `
     columns={
       Array [
         Object {
-          "columnSortable": true,
+          "Header": "Course Name",
+          "accessor": "title",
+          "disableSortBy": false,
           "key": "title",
-          "label": "Course Name",
         },
         Object {
-          "columnSortable": true,
+          "Header": "Course Number",
+          "accessor": "number",
+          "disableSortBy": false,
           "key": "number",
-          "label": "Course Number",
         },
         Object {
-          "columnSortable": false,
+          "Header": "States",
+          "accessor": "course_run_statuses",
+          "disableSortBy": true,
           "key": "course_run_statuses",
-          "label": "States",
         },
         Object {
-          "columnSortable": false,
+          "Header": "Course Editors",
+          "accessor": "course_editor_names",
+          "disableSortBy": true,
           "key": "course_editor_names",
-          "label": "Course Editors",
         },
       ]
     }
@@ -281,24 +285,28 @@ exports[`CourseTable displays table and button when user has no orgs 1`] = `
     columns={
       Array [
         Object {
-          "columnSortable": true,
+          "Header": "Course Name",
+          "accessor": "title",
+          "disableSortBy": false,
           "key": "title",
-          "label": "Course Name",
         },
         Object {
-          "columnSortable": true,
+          "Header": "Course Number",
+          "accessor": "number",
+          "disableSortBy": false,
           "key": "number",
-          "label": "Course Number",
         },
         Object {
-          "columnSortable": false,
+          "Header": "States",
+          "accessor": "course_run_statuses",
+          "disableSortBy": true,
           "key": "course_run_statuses",
-          "label": "States",
         },
         Object {
-          "columnSortable": false,
+          "Header": "Course Editors",
+          "accessor": "course_editor_names",
+          "disableSortBy": true,
           "key": "course_editor_names",
-          "label": "Course Editors",
         },
       ]
     }
@@ -435,24 +443,28 @@ exports[`CourseTable hides table and button when blacklisted 1`] = `
     columns={
       Array [
         Object {
-          "columnSortable": true,
+          "Header": "Course Name",
+          "accessor": "title",
+          "disableSortBy": false,
           "key": "title",
-          "label": "Course Name",
         },
         Object {
-          "columnSortable": true,
+          "Header": "Course Number",
+          "accessor": "number",
+          "disableSortBy": false,
           "key": "number",
-          "label": "Course Number",
         },
         Object {
-          "columnSortable": false,
+          "Header": "States",
+          "accessor": "course_run_statuses",
+          "disableSortBy": true,
           "key": "course_run_statuses",
-          "label": "States",
         },
         Object {
-          "columnSortable": false,
+          "Header": "Course Editors",
+          "accessor": "course_editor_names",
+          "disableSortBy": true,
           "key": "course_editor_names",
-          "label": "Course Editors",
         },
       ]
     }
@@ -589,24 +601,28 @@ exports[`CourseTable shows a table 1`] = `
     columns={
       Array [
         Object {
-          "columnSortable": true,
+          "Header": "Course Name",
+          "accessor": "title",
+          "disableSortBy": false,
           "key": "title",
-          "label": "Course Name",
         },
         Object {
-          "columnSortable": true,
+          "Header": "Course Number",
+          "accessor": "number",
+          "disableSortBy": false,
           "key": "number",
-          "label": "Course Number",
         },
         Object {
-          "columnSortable": false,
+          "Header": "States",
+          "accessor": "course_run_statuses",
+          "disableSortBy": true,
           "key": "course_run_statuses",
-          "label": "States",
         },
         Object {
-          "columnSortable": false,
+          "Header": "Course Editors",
+          "accessor": "course_editor_names",
+          "disableSortBy": true,
           "key": "course_editor_names",
-          "label": "Course Editors",
         },
       ]
     }

--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -186,24 +186,28 @@ class CourseTable extends React.Component {
 
     const courseTableColumns = [
       {
-        label: 'Course Name',
+        Header: 'Course Name',
         key: 'title',
         columnSortable: true,
+        accessor: 'title',
       },
       {
-        label: 'Course Number',
+        Header: 'Course Number',
         key: 'number',
         columnSortable: true,
+        accessor: 'number',
       },
       {
-        label: 'States',
+        Header: 'States',
         key: 'course_run_statuses',
         columnSortable: false,
+        accessor: 'course_run_statuses',
       },
       {
-        label: 'Course Editors',
+        Header: 'Course Editors',
         key: 'course_editor_names',
         columnSortable: false,
+        accessor: 'course_editor_names',
       },
     ];
     const formatCourseData = courses => courses.map(course => ({

--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -188,26 +188,26 @@ class CourseTable extends React.Component {
       {
         Header: 'Course Name',
         key: 'title',
-        columnSortable: true,
+        disableSortBy: false,
         accessor: 'title',
       },
       {
         Header: 'Course Number',
         key: 'number',
-        columnSortable: true,
+        disableSortBy: false,
         accessor: 'number',
       },
       {
         Header: 'States',
         key: 'course_run_statuses',
-        columnSortable: false,
         accessor: 'course_run_statuses',
+        disableSortBy: true,
       },
       {
         Header: 'Course Editors',
         key: 'course_editor_names',
-        columnSortable: false,
         accessor: 'course_editor_names',
+        disableSortBy: true,
       },
     ];
     const formatCourseData = courses => courses.map(course => ({

--- a/src/components/TableComponent/TableComponent.scss
+++ b/src/components/TableComponent/TableComponent.scss
@@ -6,7 +6,7 @@ tbody {
 }
 
 tbody {
-  height: 50vh;
+  height: auto;
   overflow-y: auto;
   overflow-x: hidden;
 
@@ -35,6 +35,11 @@ tbody {
 
 td,
 th {
-  width: 25vw;
   max-width: 25vw;
+  width: 25vw;
+}
+
+/* Manually override data table max width for td to accomodate full width size*/ 
+td.pgn__data-table-cell-wrap {
+    max-width: 25vw;
 }

--- a/src/components/TableComponent/TableComponent.test.jsx
+++ b/src/components/TableComponent/TableComponent.test.jsx
@@ -40,6 +40,7 @@ describe('CourseTable', () => {
       formatData={mockFormat}
       tableSortable
       pageCount={1}
+      itemCount={2}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -115,6 +116,7 @@ describe('CourseTable', () => {
       formatData={mockFormat}
       tableSortable
       pageCount={1}
+      itemCount={2}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -134,6 +136,7 @@ describe('CourseTable', () => {
       formatData={mockFormat}
       tableSortable
       pageCount={1}
+      itemCount={2}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -158,6 +161,7 @@ describe('CourseTable', () => {
       formatData={mockFormat}
       tableSortable
       pageCount={1}
+      itemCount={2}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}

--- a/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
+++ b/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
@@ -8,7 +8,13 @@ exports[`CourseTable shows a populated table 1`] = `
     <div
       className="table-responsive"
     >
-      <withDeprecatedProps(TableDeprecated)
+      <DataTable
+        EmptyTableComponent={[Function]}
+        FilterStatusComponent={[Function]}
+        RowStatusComponent={[Function]}
+        SelectionStatusComponent={[Function]}
+        additionalColumns={Array []}
+        bulkActions={Array []}
         className="table-sm table-striped"
         columns={
           Array [
@@ -16,13 +22,13 @@ exports[`CourseTable shows a populated table 1`] = `
               "columnSortable": true,
               "key": "col1",
               "label": "Col 1",
-              "onSort": [Function],
+              "onSort": null,
             },
             Object {
               "columnSortable": false,
               "key": "col2",
               "label": "Col 2",
-              "onSort": null,
+              "onSort": [Function],
             },
           ]
         }
@@ -38,9 +44,33 @@ exports[`CourseTable shows a populated table 1`] = `
             },
           ]
         }
+        dataViewToggleOptions={
+          Object {
+            "defaultActiveStateValue": "card",
+            "isDataViewToggleEnabled": false,
+            "onDataViewToggle": [Function],
+            "togglePlacement": "left",
+          }
+        }
+        defaultColumnValues={Object {}}
         defaultSortDirection="asc"
         defaultSortedColumn="key"
-        tableSortable={true}
+        fetchData={null}
+        initialState={Object {}}
+        initialTableOptions={Object {}}
+        isExpandable={false}
+        isFilterable={false}
+        isLoading={false}
+        isPaginated={false}
+        isSelectable={false}
+        isSortable={true}
+        itemCount={2}
+        manualFilters={false}
+        manualPagination={false}
+        manualSortBy={false}
+        numBreakoutFilters={1}
+        showFiltersInSidebar={false}
+        tableActions={Array []}
       />
     </div>
   </div>
@@ -55,7 +85,13 @@ exports[`CourseTable shows a populated table after a component update for orderi
     <div
       className="table-responsive"
     >
-      <withDeprecatedProps(TableDeprecated)
+      <DataTable
+        EmptyTableComponent={[Function]}
+        FilterStatusComponent={[Function]}
+        RowStatusComponent={[Function]}
+        SelectionStatusComponent={[Function]}
+        additionalColumns={Array []}
+        bulkActions={Array []}
         className="table-sm table-striped"
         columns={
           Array [
@@ -63,13 +99,13 @@ exports[`CourseTable shows a populated table after a component update for orderi
               "columnSortable": true,
               "key": "col1",
               "label": "Col 1",
-              "onSort": [Function],
+              "onSort": null,
             },
             Object {
               "columnSortable": false,
               "key": "col2",
               "label": "Col 2",
-              "onSort": null,
+              "onSort": [Function],
             },
           ]
         }
@@ -85,9 +121,33 @@ exports[`CourseTable shows a populated table after a component update for orderi
             },
           ]
         }
+        dataViewToggleOptions={
+          Object {
+            "defaultActiveStateValue": "card",
+            "isDataViewToggleEnabled": false,
+            "onDataViewToggle": [Function],
+            "togglePlacement": "left",
+          }
+        }
+        defaultColumnValues={Object {}}
         defaultSortDirection="desc"
         defaultSortedColumn="key"
-        tableSortable={true}
+        fetchData={null}
+        initialState={Object {}}
+        initialTableOptions={Object {}}
+        isExpandable={false}
+        isFilterable={false}
+        isLoading={false}
+        isPaginated={false}
+        isSelectable={false}
+        isSortable={true}
+        itemCount={2}
+        manualFilters={false}
+        manualPagination={false}
+        manualSortBy={false}
+        numBreakoutFilters={1}
+        showFiltersInSidebar={false}
+        tableActions={Array []}
       />
     </div>
   </div>
@@ -102,7 +162,13 @@ exports[`CourseTable shows a populated table after a component update for page 1
     <div
       className="table-responsive"
     >
-      <withDeprecatedProps(TableDeprecated)
+      <DataTable
+        EmptyTableComponent={[Function]}
+        FilterStatusComponent={[Function]}
+        RowStatusComponent={[Function]}
+        SelectionStatusComponent={[Function]}
+        additionalColumns={Array []}
+        bulkActions={Array []}
         className="table-sm table-striped"
         columns={
           Array [
@@ -110,13 +176,13 @@ exports[`CourseTable shows a populated table after a component update for page 1
               "columnSortable": true,
               "key": "col1",
               "label": "Col 1",
-              "onSort": [Function],
+              "onSort": null,
             },
             Object {
               "columnSortable": false,
               "key": "col2",
               "label": "Col 2",
-              "onSort": null,
+              "onSort": [Function],
             },
           ]
         }
@@ -132,9 +198,33 @@ exports[`CourseTable shows a populated table after a component update for page 1
             },
           ]
         }
+        dataViewToggleOptions={
+          Object {
+            "defaultActiveStateValue": "card",
+            "isDataViewToggleEnabled": false,
+            "onDataViewToggle": [Function],
+            "togglePlacement": "left",
+          }
+        }
+        defaultColumnValues={Object {}}
         defaultSortDirection="asc"
         defaultSortedColumn="key"
-        tableSortable={true}
+        fetchData={null}
+        initialState={Object {}}
+        initialTableOptions={Object {}}
+        isExpandable={false}
+        isFilterable={false}
+        isLoading={false}
+        isPaginated={false}
+        isSelectable={false}
+        isSortable={true}
+        itemCount={2}
+        manualFilters={false}
+        manualPagination={false}
+        manualSortBy={false}
+        numBreakoutFilters={1}
+        showFiltersInSidebar={false}
+        tableActions={Array []}
       />
     </div>
   </div>

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import qs from 'query-string';
-import { Pagination, Table } from '@edx/paragon';
+import { Pagination, DataTable } from '@edx/paragon';
 import 'font-awesome/css/font-awesome.css';
 
 import './TableComponent.scss';
@@ -90,11 +90,11 @@ class TableComponent extends React.Component {
       <div className={className}>
         {loading && <LoadingSpinner />}
         <div className="table-responsive">
-          <Table
+          <DataTable
             className="table-sm table-striped"
             columns={columnConfig}
             data={formatData(data)}
-            tableSortable={tableSortable}
+            isSortable={tableSortable}
             defaultSortedColumn={sortColumn}
             defaultSortDirection={sortDirection}
           />

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -60,6 +60,7 @@ class TableComponent extends React.Component {
     const {
       className,
       pageCount,
+      itemCount,
       tableSortable,
       data,
       formatData,
@@ -69,12 +70,11 @@ class TableComponent extends React.Component {
 
     const columnConfig = this.props.columns.map(column => ({
       ...column,
-      onSort: column.columnSortable ? direction => updateUrl({
+      onSort: !column.columnSortable ? direction => updateUrl({
         page: 1,
         ordering: direction === 'desc' ? `-${column.key}` : column.key,
       }) : null,
     }));
-
     let sortDirection;
     let sortColumn;
 
@@ -95,6 +95,7 @@ class TableComponent extends React.Component {
             columns={columnConfig}
             data={formatData(data)}
             isSortable={tableSortable}
+            itemCount={itemCount}
             defaultSortedColumn={sortColumn}
             defaultSortDirection={sortDirection}
           />
@@ -171,6 +172,7 @@ TableComponent.propTypes = {
   // Props expected from TableContainer / redux store
   data: PropTypes.arrayOf(PropTypes.shape({})),
   pageCount: PropTypes.number.isRequired,
+  itemCount: PropTypes.number.isRequired,
   loading: PropTypes.bool,
   error: PropTypes.instanceOf(Error),
   paginateTable: PropTypes.func.isRequired,

--- a/src/containers/TableContainer/index.jsx
+++ b/src/containers/TableContainer/index.jsx
@@ -12,6 +12,7 @@ const mapStateToProps = (state) => {
   return {
     data: tableState.data && tableState.data.results,
     pageCount: (tableState.data && Math.ceil(tableState.data.count / PAGE_SIZE)) || 1,
+    itemCount: (tableState.data && tableState.data.count) || 0,
     loading: tableState.loading,
     error: tableState.error,
     editorFilterOptions: tableState.editorFilterOptions,


### PR DESCRIPTION
### [PROD-2728](https://openedx.atlassian.net/browse/PROD-2728)

### Description

Part 1 of replacing the Course listing table in publisher with Paragon's data table. The changes in this PR:

- Replacement of Table with DataTable
- Change cell width to fix header-data misalignment
- Make the height of the table auto instead of fixed height
- Keep sorting on title and course key

The follow-up PR will focus on using table filters and showing empty status from the data table instead of the existing error messsage. 

### References

- https://paragon-openedx.netlify.app/components/datatable/
- https://react-table.tanstack.com/docs/api/useTable

### Screenshots

#### Old
<img width="1637" alt="image" src="https://user-images.githubusercontent.com/40599381/162939814-7934b9bd-5d1c-4e1e-bcd4-60e26d84cf95.png">

#### New

<img width="1637" alt="image" src="https://user-images.githubusercontent.com/40599381/162939933-01b4eadf-7cac-453d-96f8-64c13bae9d5f.png">

