### PR TITLE
feat: data table updates

### DIFF
--- a/src/components/LoadingSpinner/__snapshots__/LoadingSpinner.test.jsx.snap
+++ b/src/components/LoadingSpinner/__snapshots__/LoadingSpinner.test.jsx.snap
@@ -7,9 +7,10 @@ exports[`LoadingSpinner shows a loading spinner 1`] = `
   <div>
     Loading…
   </div>
-  <withDeprecatedProps(Icon)
-    className="fa fa-circle-o-notch fa-spin fa-3x fa-fw"
-    id="spinner"
+  <ForwardRef
+    animation="border"
+    className="mie-3"
+    screenReaderText="loading"
   />
 </div>
 `;

--- a/src/components/LoadingSpinner/index.jsx
+++ b/src/components/LoadingSpinner/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Icon } from '@edx/paragon';
+import { Spinner } from '@edx/paragon';
 import PropTypes from 'prop-types';
 
 const LoadingSpinner = props => (
@@ -7,10 +7,7 @@ const LoadingSpinner = props => (
     <div>
       { props.message }
     </div>
-    <Icon
-      id="spinner"
-      className="fa fa-circle-o-notch fa-spin fa-3x fa-fw"
-    />
+    <Spinner animation="border" className="mie-3" screenReaderText="loading" />
   </div>
 );
 

--- a/src/components/TableComponent/TableComponent.scss
+++ b/src/components/TableComponent/TableComponent.scss
@@ -42,4 +42,5 @@ th {
 /* Manually override data table max width for td to accomodate full width size*/ 
 td.pgn__data-table-cell-wrap {
     max-width: 25vw;
+    word-break: break-all;
 }

--- a/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
+++ b/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
@@ -235,20 +235,66 @@ exports[`CourseTable shows a table 1`] = `<Fragment />`;
 
 exports[`CourseTable shows an empty table 1`] = `
 <Fragment>
-  <StatusAlert
-    alertType="warning"
-    className=""
-    dismissible={false}
-    iconClassNames={
-      Array [
-        "fa",
-        "fa-exclamation-circle",
-      ]
-    }
-    message="There are no results."
-    onClose={[Function]}
-    title={null}
-  />
+  <div
+    className="test"
+  >
+    <div
+      className="table-responsive"
+    >
+      <DataTable
+        EmptyTableComponent={[Function]}
+        FilterStatusComponent={[Function]}
+        RowStatusComponent={[Function]}
+        SelectionStatusComponent={[Function]}
+        additionalColumns={Array []}
+        bulkActions={Array []}
+        className="table-sm table-striped"
+        columns={
+          Array [
+            Object {
+              "columnSortable": true,
+              "key": "col1",
+              "label": "Col 1",
+              "onSort": null,
+            },
+            Object {
+              "columnSortable": false,
+              "key": "col2",
+              "label": "Col 2",
+              "onSort": [Function],
+            },
+          ]
+        }
+        data={Array []}
+        dataViewToggleOptions={
+          Object {
+            "defaultActiveStateValue": "card",
+            "isDataViewToggleEnabled": false,
+            "onDataViewToggle": [Function],
+            "togglePlacement": "left",
+          }
+        }
+        defaultColumnValues={Object {}}
+        defaultSortDirection="asc"
+        defaultSortedColumn="key"
+        fetchData={null}
+        initialState={Object {}}
+        initialTableOptions={Object {}}
+        isExpandable={false}
+        isFilterable={false}
+        isLoading={false}
+        isPaginated={false}
+        isSelectable={false}
+        isSortable={true}
+        manualFilters={false}
+        manualPagination={false}
+        manualSortBy={false}
+        numBreakoutFilters={1}
+        showFiltersInSidebar={false}
+        tableActions={Array []}
+      />
+    </div>
+  </div>
 </Fragment>
 `;
 

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -154,9 +154,7 @@ class TableComponent extends React.Component {
       <>
         {error && this.renderErrorMessage()}
         {loading && !data && this.renderLoadingMessage()}
-        {!loading && !error && data && data.length === 0
-          && this.renderEmptyDataMessage()}
-        {data && data.length > 0 && this.renderTableContent()}
+        {data && this.renderTableContent()}
       </>
     );
   }


### PR DESCRIPTION
### [PROD-2728](https://openedx.atlassian.net/browse/PROD-2728)

### Description

- Let DataTable handle no data found/empty state
- Use paragon [spinner component](https://paragon-openedx.netlify.app/components/spinner/) in loading spinner
- Word break table data to avoid overflows


### Screenshots

#### Old

<img width="1644" alt="image" src="https://user-images.githubusercontent.com/40599381/164238952-8cd96c02-6154-4790-b18e-82e6083dd7ad.png">

<img width="1644" alt="image" src="https://user-images.githubusercontent.com/40599381/164239056-2deca719-8391-4b62-93f4-65196c809956.png">

#### New

<img width="1644" alt="image" src="https://user-images.githubusercontent.com/40599381/164239218-be6e5dd8-0c46-4adf-95f4-3fcc54c6cdee.png">

<img width="1644" alt="image" src="https://user-images.githubusercontent.com/40599381/164239290-851936c7-9b10-4be5-bfc1-36ce7ef60652.png">
