### PR TITLE
feat: add navigation to course groups

### DIFF
--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -59,6 +59,7 @@ class CourseTable extends React.Component {
       },
     } = this.props;
     const { administrator } = getAuthenticatedUser();
+    const { selectedFilters } = this.state;
     const prevEditorFilterOptions = prevProps.table.editorFilterOptions;
 
     if (editorFilterOptions !== prevEditorFilterOptions && !administrator) {
@@ -71,13 +72,18 @@ class CourseTable extends React.Component {
     const {
       editors: prevEditors,
       course_run_statuses: prevCourseRunStatuses,
+      course_type: prevCourseType,
     } = qs.parse(prevProps.location.search);
     const {
       editors,
       course_run_statuses: courseRunStatuses,
+      course_type: courseType,
     } = qs.parse(this.props.location.search);
     if ((editors !== prevEditors) || (courseRunStatuses !== prevCourseRunStatuses)) {
       this.getSelectedFiltersFromUrl();
+    }
+    if (courseType !== prevCourseType) {
+      this.updateFilterQueryParamsInUrl(selectedFilters);
     }
   }
 

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -5,3 +5,8 @@
     max-width: 100px;
   }
 }
+
+.disabled-link {
+  pointer-events: none;
+  color: $gray-300;
+}

--- a/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -39,26 +39,73 @@ exports[`Header renders the correct header 1`] = `
         </withDeprecatedProps(Hyperlink)>
       </div>
       <div
-        className="col"
+        className="col-auto justify-content-start"
       >
         <Link
+          className=""
           to="/"
         >
           <LinkAnchor
+            className=""
             href="/"
             navigate={[Function]}
           >
             <a
+              className=""
               href="/"
               onClick={[Function]}
             >
-              Courses
+              Open Courses
             </a>
           </LinkAnchor>
         </Link>
       </div>
       <div
-        className="col-auto justify-content-end"
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=executive-education-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=executive-education-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=executive-education-2u"
+              onClick={[Function]}
+            >
+              Exective Education
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=bootcamp-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=bootcamp-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=bootcamp-2u"
+              onClick={[Function]}
+            >
+              Bootcamps
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-end ml-auto"
       >
         <Dropdown
           navbar={false}
@@ -227,20 +274,67 @@ exports[`Header renders the header correctly when toggling is allowed, and dark 
         </withDeprecatedProps(Hyperlink)>
       </div>
       <div
-        className="col"
+        className="col-auto justify-content-start"
       >
         <Link
+          className=""
           to="/"
         >
           <LinkAnchor
+            className=""
             href="/"
             navigate={[Function]}
           >
             <a
+              className=""
               href="/"
               onClick={[Function]}
             >
-              Courses
+              Open Courses
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=executive-education-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=executive-education-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=executive-education-2u"
+              onClick={[Function]}
+            >
+              Exective Education
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=bootcamp-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=bootcamp-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=bootcamp-2u"
+              onClick={[Function]}
+            >
+              Bootcamps
             </a>
           </LinkAnchor>
         </Link>
@@ -258,7 +352,7 @@ exports[`Header renders the header correctly when toggling is allowed, and dark 
         </button>
       </div>
       <div
-        className="col-auto justify-content-end"
+        className="col-auto justify-content-end ml-auto"
       >
         <Dropdown
           navbar={false}
@@ -427,20 +521,67 @@ exports[`Header renders the header correctly when users pass a querystring param
         </withDeprecatedProps(Hyperlink)>
       </div>
       <div
-        className="col"
+        className="col-auto justify-content-start"
       >
         <Link
+          className=""
           to="/"
         >
           <LinkAnchor
+            className=""
             href="/"
             navigate={[Function]}
           >
             <a
+              className=""
               href="/"
               onClick={[Function]}
             >
-              Courses
+              Open Courses
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=executive-education-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=executive-education-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=executive-education-2u"
+              onClick={[Function]}
+            >
+              Exective Education
+            </a>
+          </LinkAnchor>
+        </Link>
+      </div>
+      <div
+        className="col-auto justify-content-start"
+      >
+        <Link
+          className=""
+          to="/?course_type=bootcamp-2u"
+        >
+          <LinkAnchor
+            className=""
+            href="/?course_type=bootcamp-2u"
+            navigate={[Function]}
+          >
+            <a
+              className=""
+              href="/?course_type=bootcamp-2u"
+              onClick={[Function]}
+            >
+              Bootcamps
             </a>
           </LinkAnchor>
         </Link>
@@ -458,7 +599,7 @@ exports[`Header renders the header correctly when users pass a querystring param
         </button>
       </div>
       <div
-        className="col-auto justify-content-end"
+        className="col-auto justify-content-end ml-auto"
       >
         <Dropdown
           navbar={false}

--- a/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -77,7 +77,7 @@ exports[`Header renders the correct header 1`] = `
               href="/?course_type=executive-education-2u"
               onClick={[Function]}
             >
-              Exective Education
+              Executive Education
             </a>
           </LinkAnchor>
         </Link>
@@ -312,7 +312,7 @@ exports[`Header renders the header correctly when toggling is allowed, and dark 
               href="/?course_type=executive-education-2u"
               onClick={[Function]}
             >
-              Exective Education
+              Executive Education
             </a>
           </LinkAnchor>
         </Link>
@@ -559,7 +559,7 @@ exports[`Header renders the header correctly when users pass a querystring param
               href="/?course_type=executive-education-2u"
               onClick={[Function]}
             >
-              Exective Education
+              Executive Education
             </a>
           </LinkAnchor>
         </Link>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -19,7 +19,13 @@ const Header = ({ darkModeOn, location, toggleDarkMode }) => {
 
   // Allow users to toggle dark mode on if they put in a querystring like ?bananas=1
   const querystringParams = qs.parse(location.search);
+  const { pathname } = location;
   const allowDarkModeToggle = querystringParams.bananas;
+
+  function disableLink(courseType) {
+    const courseTypeFromURL = querystringParams.course_type ? querystringParams.course_type : '';
+    return (courseTypeFromURL === courseType && pathname === '/') ? 'disabled-link' : '';
+  }
 
   return (
     <header className="site-header mb-3 py-3 border-bottom-blue">
@@ -30,9 +36,16 @@ const Header = ({ darkModeOn, location, toggleDarkMode }) => {
               <img src={process.env.LOGO_URL} alt="edX logo" height="30" width="60" />
             </Hyperlink>
           </div>
-          <div className="col">
-            <Link to="/">Courses</Link>
+          <div className="col-auto justify-content-start">
+            <Link to="/" className={disableLink('')}>Open Courses</Link>
           </div>
+          <div className="col-auto justify-content-start">
+            <Link to="/?course_type=executive-education-2u" className={disableLink('executive-education-2u')}>Executive Education</Link>
+          </div>
+          <div className="col-auto justify-content-start">
+            <Link to="/?course_type=bootcamp-2u" className={disableLink('bootcamp-2u')}>Bootcamps</Link>
+          </div>
+
           {allowDarkModeToggle
             && (
             <div className="col-auto justify-content-end">
@@ -41,7 +54,7 @@ const Header = ({ darkModeOn, location, toggleDarkMode }) => {
               </button>
             </div>
             )}
-          <div className="col-auto justify-content-end">
+          <div className="col-auto justify-content-end ml-auto">
             <>
               <Dropdown>
                 <Dropdown.Toggle as={AvatarButton}>
@@ -69,6 +82,7 @@ Header.propTypes = {
   darkModeOn: PropTypes.bool,
   location: PropTypes.shape({
     search: PropTypes.string,
+    pathname: PropTypes.string,
   }),
   toggleDarkMode: PropTypes.func,
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -63,6 +63,7 @@ const getPageOptionsFromUrl = () => {
     filter: undefined,
     editors: undefined,
     course_run_statuses: undefined,
+    course_type: 'open-courses',
   };
   const query = qs.parse(window.location.search);
   return {
@@ -72,6 +73,7 @@ const getPageOptionsFromUrl = () => {
     pubq: query.filter || defaults.filter,
     editors: query.editors || defaults.editors,
     course_run_statuses: query.course_run_statuses || defaults.course_run_statuses,
+    course_type: query.course_type || defaults.course_type,
   };
 };
 


### PR DESCRIPTION
## Description:
This PR will add navigation routes to different course filters. 

## Linked Ticket:
[PROD-2780](https://openedx.atlassian.net/browse/PROD-2780)

## Logic:
Existing implementation for query parameters handling in course tables page is little tricky. It caters filters and search side by side and some utility functions are naive e.g. filtering of `selectedFilters` from component state while updating url. In order to work with existing implementation and not break them, this solution has been added this way. This could be improved along with updating logic for handling existing query parameters and filters. 

## TODO:
- [ ] add unit test once the approach is accepted
- [x] highlight navigation route in use
- [ ] use state variable for course type if needed
- [x] resolve issue with changing url when route double clicked (UI + removes existing filters)
- [ ] comment approach if existing handling is updated 