### PR TITLE
feat: make staff optional for bootcamps

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -103,7 +103,11 @@ const editCourseValidate = (values, props) => {
         && registeredFields['prices.paid-executive-education']
         && registeredFields['prices.paid-executive-education'].count;
 
-      const runRequiredFields = isExecutiveEducation ? ['transcript_languages'] : ['transcript_languages', 'staff'];
+      const isBootcamp = registeredFields
+        && registeredFields['prices.paid-bootcamp']
+        && registeredFields['prices.paid-bootcamp'].count;
+
+      const runRequiredFields = (isExecutiveEducation || isBootcamp) ? ['transcript_languages'] : ['transcript_languages', 'staff'];
       const runErrors = {};
       runRequiredFields.forEach((fieldName) => {
         const value = run[fieldName];

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -248,4 +248,34 @@ describe('editCourseValidate', () => {
       },
     })).toEqual({});
   });
+  it('returns no error on submitting 2U bootcamp runs with missing staff', () => {
+    const values = {
+      short_description: 'Short',
+      full_description: 'Full',
+      outcome: 'Outcome',
+      imageSrc: 'base64;encodedimage',
+      course_runs: [
+        {
+          key: 'NonSubmittingTestRun',
+        },
+        {
+          key: 'TestRun',
+          transcript_languages: [
+            {
+              dummy_field: 'Transcript languages dummy field',
+            },
+          ],
+          staff: [],
+        },
+      ],
+    };
+    expect(editCourseValidate(values, {
+      targetRun: unpublishedTargetRun,
+      registeredFields: {
+        'prices.paid-bootcamp': {
+          count: 1,
+        },
+      },
+    })).toEqual({});
+  });
 });


### PR DESCRIPTION
## Description:
This PR will add a check to make `staff` field optional for `Bootcamp` courses. 

## Linked Ticket:
[PROD-2833](https://openedx.atlassian.net/browse/PROD-2833)

## Similar PRs:
- #662 
- #694 

## TODO
- [ ] Verify behavior locally 