### PR TITLE
feat: add start_date and registration_deadline in AdditionoalMetadata

### DIFF
--- a/src/components/EditCoursePage/AdditionalMetadataFields.jsx
+++ b/src/components/EditCoursePage/AdditionalMetadataFields.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import RenderInputTextField from '../RenderInputTextField';
 import FieldLabel from '../FieldLabel';
 import RichEditor from '../RichEditor';
+import { utcTimeZone } from '../../utils';
+import DateTimeField from '../DateTimeField';
 
 function AdditionalMetadataFields(props) {
   const {
@@ -86,6 +88,25 @@ function AdditionalMetadataFields(props) {
           label=<FieldLabel id="certificate-info.blurb" text="Description" />
           disabled={disabled}
           required
+        />
+        <Field
+          name="additional_metadata.start_date"
+          type="date"
+          component={DateTimeField}
+          dateLabel="Start Date"
+          timeLabel={`Start Time (${utcTimeZone})`}
+          utcTimeZone
+          disabled={disabled}
+          required
+        />
+        <Field
+          name="additional_metadata.registration_deadline"
+          type="date"
+          component={DateTimeField}
+          dateLabel="Registration Deadline Date"
+          timeLabel={`Registration Deadline Time (${utcTimeZone})`}
+          utcTimeZone
+          disabled={disabled}
         />
       </div>
     </div>

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -45,6 +45,8 @@ describe('EditCoursePage', () => {
           heading: 'facts_2_heading',
           blurb: 'facts_2_blurb',
         }],
+        start_date: '2019-05-10T00:00:00Z',
+        registration_deadline: '2019-05-10T00:00:00Z',
       },
       course_runs: [
         {
@@ -342,6 +344,8 @@ describe('EditCoursePage', () => {
         facts_1_blurb: 'facts_1_blurb',
         facts_2_heading: 'facts_2_heading',
         facts_2_blurb: 'facts_2_blurb',
+        start_date: '2019-05-10T00:00:00Z',
+        registration_deadline: '2019-05-10T00:00:00Z',
       },
       course_runs: [unpublishedCourseRun, publishedCourseRun],
       faq: '<p>Help?</p>',
@@ -884,6 +888,8 @@ describe('EditCoursePage', () => {
           heading: 'facts_2_heading',
           blurb: 'facts_2_blurb',
         }],
+        start_date: '2019-05-10T00:00:00Z',
+        registration_deadline: '2019-05-10T00:00:00Z',
       },
       draft: false,
       collaborators: undefined,

--- a/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
@@ -199,6 +199,25 @@ exports[`AdditionalMetadata Fields Display all fields 1`] = `
       name="additional_metadata.certificate_info_blurb"
       required={true}
     />
+    <Field
+      component={[Function]}
+      dateLabel="Start Date"
+      disabled={false}
+      name="additional_metadata.start_date"
+      required={true}
+      timeLabel="Start Time (UTC)"
+      type="date"
+      utcTimeZone={true}
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Registration Deadline Date"
+      disabled={false}
+      name="additional_metadata.registration_deadline"
+      timeLabel="Registration Deadline Time (UTC)"
+      type="date"
+      utcTimeZone={true}
+    />
   </div>
 </div>
 `;

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -283,6 +283,8 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
               ],
               "lead_capture_form_url": "https://www.lead_capture_url.com",
               "organic_url": "https://www.organic_url.com",
+              "registration_deadline": "2019-05-10T00:00:00Z",
+              "start_date": "2019-05-10T00:00:00Z",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -500,6 +502,8 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             "facts_2_heading": "facts_2_heading",
             "lead_capture_form_url": "https://www.lead_capture_url.com",
             "organic_url": "https://www.organic_url.com",
+            "registration_deadline": "2019-05-10T00:00:00Z",
+            "start_date": "2019-05-10T00:00:00Z",
           },
           "collaborators": Array [],
           "course_runs": Array [
@@ -709,6 +713,8 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
               ],
               "lead_capture_form_url": "https://www.lead_capture_url.com",
               "organic_url": "https://www.organic_url.com",
+              "registration_deadline": "2019-05-10T00:00:00Z",
+              "start_date": "2019-05-10T00:00:00Z",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -1209,6 +1215,8 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             "facts_2_heading": "facts_2_heading",
             "lead_capture_form_url": "https://www.lead_capture_url.com",
             "organic_url": "https://www.organic_url.com",
+            "registration_deadline": "2019-05-10T00:00:00Z",
+            "start_date": "2019-05-10T00:00:00Z",
           },
           "collaborators": Array [],
           "course_runs": Array [
@@ -1587,6 +1595,8 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
               ],
               "lead_capture_form_url": "https://www.lead_capture_url.com",
               "organic_url": "https://www.organic_url.com",
+              "registration_deadline": "2019-05-10T00:00:00Z",
+              "start_date": "2019-05-10T00:00:00Z",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -2155,6 +2165,8 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             "facts_2_heading": "facts_2_heading",
             "lead_capture_form_url": "https://www.lead_capture_url.com",
             "organic_url": "https://www.organic_url.com",
+            "registration_deadline": "2019-05-10T00:00:00Z",
+            "start_date": "2019-05-10T00:00:00Z",
           },
           "collaborators": Array [],
           "course_runs": Array [

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -188,6 +188,8 @@ class EditCoursePage extends React.Component {
         heading: courseData.additional_metadata.facts_2_heading,
         blurb: courseData.additional_metadata.facts_2_blurb,
       }],
+      start_date: courseData.additional_metadata.start_date,
+      registration_deadline: courseData.additional_metadata.registration_deadline,
     };
   }
 
@@ -351,6 +353,8 @@ class EditCoursePage extends React.Component {
         facts_1_blurb: additional_metadata.facts[0]?.blurb,
         facts_2_heading: additional_metadata.facts[1]?.heading,
         facts_2_blurb: additional_metadata.facts[1]?.blurb,
+        start_date: additional_metadata.start_date,
+        registration_deadline: additional_metadata.registration_deadline,
       };
     }
     return {};


### PR DESCRIPTION
### Description 
This PR adds `start_date` and `registration_deadline` fields in Course Edit form under Additional Metadata.

### Linked Ticket
[PROD-2864](https://2u-internal.atlassian.net/browse/PROD-2864)

### Testing Instructions
1. Checkout latest master from openedx/course-discovery and apply migrations
2. Checkout this branch
3. Edit course input dates in new fields
4. Verify from db/api if they are added in related course
5. Verify from UI that the values are reflected in form 