### PR TITLE
feat: add ability to edit course's value_per_click

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -255,7 +255,6 @@ export class BaseEditCourseForm extends React.Component {
       runTypeModes,
     } = parsedTypeOptions;
     const disabled = courseInReview || !editable;
-    console.log({currentFormValues});
     const showMarketingFields = !currentFormValues.type || !courseTypes[currentFormValues.type]
       || courseTypes[currentFormValues.type].course_run_types.some(crt => crt.is_marketable);
 

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -187,7 +187,6 @@ export class BaseEditCourseForm extends React.Component {
   }
 
   render() {
-    console.log('props', this.props);
     const {
       handleSubmit,
       number,

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -937,7 +937,7 @@ export class BaseEditCourseForm extends React.Component {
             {administrator && (
               <>
                 <Field
-                  name="value_per_click_usa"
+                  name="in_year_value_data.per_click_usa"
                   component={RenderInputTextField}
                   label={<FieldLabel text="Value Per Click USA" optional />}
                   extraInput={{ onInvalid: this.openCollapsible }}
@@ -945,7 +945,7 @@ export class BaseEditCourseForm extends React.Component {
                   optional
                 />
                 <Field
-                  name="value_per_click_international"
+                  name="in_year_value_data.per_click_international"
                   component={RenderInputTextField}
                   label={<FieldLabel text="Value Per Click International" optional />}
                   extraInput={{ onInvalid: this.openCollapsible }}
@@ -1044,8 +1044,12 @@ BaseEditCourseForm.propTypes = {
       course_type: PropTypes.string,
       organization_logo_override_url: PropTypes.string,
       organization_short_code_override: PropTypes.string,
-      value_per_click_usa: PropTypes.number,
-      value_per_click_international: PropTypes.number,
+      in_year_value_data: PropTypes.shape({
+        'per_click_usa': PropTypes.number,
+        'per_click_international': PropTypes.number,
+        'per_lead_usa': PropTypes.number,
+        'per_lead_international': PropTypes.number,
+      }),
     }),
   }),
   courseSubmitInfo: PropTypes.shape({

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -66,7 +66,6 @@ export class BaseEditCourseForm extends React.Component {
       },
       updateFormValuesAfterSave,
     } = this.props;
-
     if (initialCourseRuns.length && !this.state.collapsiblesOpen.length) {
       this.setCourseRunCollapsibles(initialCourseRuns);
     }
@@ -188,6 +187,7 @@ export class BaseEditCourseForm extends React.Component {
   }
 
   render() {
+    console.log('props', this.props);
     const {
       handleSubmit,
       number,
@@ -255,6 +255,7 @@ export class BaseEditCourseForm extends React.Component {
       runTypeModes,
     } = parsedTypeOptions;
     const disabled = courseInReview || !editable;
+    console.log({currentFormValues});
     const showMarketingFields = !currentFormValues.type || !courseTypes[currentFormValues.type]
       || courseTypes[currentFormValues.type].course_run_types.some(crt => crt.is_marketable);
 
@@ -932,6 +933,22 @@ export class BaseEditCourseForm extends React.Component {
               maxImageSizeKilo={256}
               requiredWidth={110}
               requiredHeight={110}
+              disabled={disabled}
+              optional
+            />
+            <Field
+              name="value_per_click_usa"
+              component={RenderInputTextField}
+              label={<FieldLabel text="Value Per Click USA" optional />}
+              extraInput={{ onInvalid: this.openCollapsible }}
+              disabled={disabled}
+              optional
+            />
+            <Field
+              name="value_per_click_international"
+              component={RenderInputTextField}
+              label={<FieldLabel text="Value Per Click International" optional />}
+              extraInput={{ onInvalid: this.openCollapsible }}
               disabled={disabled}
               optional
             />

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -936,22 +936,26 @@ export class BaseEditCourseForm extends React.Component {
               disabled={disabled}
               optional
             />
-            <Field
-              name="value_per_click_usa"
-              component={RenderInputTextField}
-              label={<FieldLabel text="Value Per Click USA" optional />}
-              extraInput={{ onInvalid: this.openCollapsible }}
-              disabled={disabled}
-              optional
-            />
-            <Field
-              name="value_per_click_international"
-              component={RenderInputTextField}
-              label={<FieldLabel text="Value Per Click International" optional />}
-              extraInput={{ onInvalid: this.openCollapsible }}
-              disabled={disabled}
-              optional
-            />
+            {administrator && (
+              <>
+                <Field
+                  name="value_per_click_usa"
+                  component={RenderInputTextField}
+                  label={<FieldLabel text="Value Per Click USA" optional />}
+                  extraInput={{ onInvalid: this.openCollapsible }}
+                  disabled={disabled}
+                  optional
+                />
+                <Field
+                  name="value_per_click_international"
+                  component={RenderInputTextField}
+                  label={<FieldLabel text="Value Per Click International" optional />}
+                  extraInput={{ onInvalid: this.openCollapsible }}
+                  disabled={disabled}
+                  optional
+                />
+              </>
+            )}
           </Collapsible>
           {open && courseType && courseType === EXECUTIVE_EDUCATION_SLUG && (
             <AdditionalMetadataFields disabled={disabled} />
@@ -1042,6 +1046,8 @@ BaseEditCourseForm.propTypes = {
       course_type: PropTypes.string,
       organization_logo_override_url: PropTypes.string,
       organization_short_code_override: PropTypes.string,
+      value_per_click_usa: PropTypes.number,
+      value_per_click_international: PropTypes.number,
     }),
   }),
   courseSubmitInfo: PropTypes.shape({

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -34,8 +34,12 @@ describe('BaseEditCourseForm', () => {
     skill_names: [],
     organization_logo_override: 'http://image.src.small',
     organization_short_code_override: 'test short code',
-    value_per_click_usa: '10',
-    value_per_click_international: '20',
+    in_year_value_data = {
+      'per_click_usa': 150,
+      'per_click_international': 125,
+      'per_lead_usa': 150,
+      'per_lead_international': 125
+    }
   };
 
   const courseInfo = {

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -34,6 +34,8 @@ describe('BaseEditCourseForm', () => {
     skill_names: [],
     organization_logo_override: 'http://image.src.small',
     organization_short_code_override: 'test short code',
+    value_per_click_usa: '10',
+    value_per_click_international: '20',
   };
 
   const courseInfo = {

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -992,6 +992,48 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
+      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -1475,6 +1517,8 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -2596,6 +2640,48 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
+      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -3079,6 +3165,8 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -3116,6 +3204,8 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -4323,6 +4413,48 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
         requiredHeight={110}
         requiredWidth={110}
       />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
+      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -4806,6 +4938,8 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -4843,6 +4977,8 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -5948,6 +6084,48 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
+      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -6431,6 +6609,8 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -6468,6 +6648,8 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           "title": "Test Title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "uuid": "11111111-1111-1111-1111-111111111111",
+          "value_per_click_international": "20",
+          "value_per_click_usa": "10",
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
@@ -7568,6 +7750,48 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
         optional={true}
         requiredHeight={110}
         requiredWidth={110}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
       />
     </CustomCollapsible>
     <FieldLabel
@@ -9162,6 +9386,48 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
         optional={true}
         requiredHeight={110}
         requiredWidth={110}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click USA"
+          />
+        }
+        name="value_per_click_usa"
+        optional={true}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id={null}
+            optional={true}
+            text="Value Per Click International"
+          />
+        }
+        name="value_per_click_international"
+        optional={true}
       />
     </CustomCollapsible>
     <FieldLabel

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -992,48 +992,6 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click USA"
-          />
-        }
-        name="value_per_click_usa"
-        optional={true}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click International"
-          />
-        }
-        name="value_per_click_international"
-        optional={true}
-      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -2639,48 +2597,6 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
         optional={true}
         requiredHeight={110}
         requiredWidth={110}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click USA"
-          />
-        }
-        name="value_per_click_usa"
-        optional={true}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click International"
-          />
-        }
-        name="value_per_click_international"
-        optional={true}
       />
     </CustomCollapsible>
     <FieldLabel
@@ -6084,48 +6000,6 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click USA"
-          />
-        }
-        name="value_per_click_usa"
-        optional={true}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click International"
-          />
-        }
-        name="value_per_click_international"
-        optional={true}
-      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -7751,48 +7625,6 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
         requiredHeight={110}
         requiredWidth={110}
       />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click USA"
-          />
-        }
-        name="value_per_click_usa"
-        optional={true}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click International"
-          />
-        }
-        name="value_per_click_international"
-        optional={true}
-      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"
@@ -9386,48 +9218,6 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
         optional={true}
         requiredHeight={110}
         requiredWidth={110}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click USA"
-          />
-        }
-        name="value_per_click_usa"
-        optional={true}
-      />
-      <Field
-        component={[Function]}
-        disabled={true}
-        extraInput={
-          Object {
-            "onInvalid": [Function],
-          }
-        }
-        label={
-          <FieldLabel
-            className=""
-            extraText=""
-            helpText=""
-            id={null}
-            optional={true}
-            text="Value Per Click International"
-          />
-        }
-        name="value_per_click_international"
-        optional={true}
       />
     </CustomCollapsible>
     <FieldLabel

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -135,6 +135,8 @@ exports[`EditCoursePage renders html correctly 1`] = `
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -596,6 +598,8 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
           "title": "Test title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": "https://www.video.information/watch?v=cVsQLlk-T0s",
         }
       }
@@ -1320,6 +1324,8 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
           "title": "Test title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": "https://www.video.information/watch?v=cVsQLlk-T0s",
         }
       }
@@ -1483,6 +1489,8 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -2286,6 +2294,8 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "title": "Test title",
           "type": "8a8f30e1-23ce-4ed3-a361-1325c656b67b",
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": "https://www.video.information/watch?v=cVsQLlk-T0s",
         }
       }
@@ -2465,6 +2475,8 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -2922,6 +2934,8 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -3085,6 +3099,8 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -3323,6 +3339,8 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }
@@ -3486,6 +3504,8 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
           "title": undefined,
           "type": undefined,
           "url_slug": undefined,
+          "value_per_click_international": undefined,
+          "value_per_click_usa": undefined,
           "videoSrc": undefined,
         }
       }

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -238,6 +238,8 @@ class EditCoursePage extends React.Component {
       type: courseData.type,
       url_slug: courseData.url_slug,
       uuid,
+      value_per_click_usa: courseData.value_per_click_usa,
+      value_per_click_international: courseData.value_per_click_international,
       video: { src: courseData.videoSrc },
       enterprise_subscription_inclusion: courseData.enterprise_subscription_inclusion,
     };
@@ -442,6 +444,8 @@ class EditCoursePage extends React.Component {
           enterprise_subscription_inclusion,
           organization_short_code_override,
           organization_logo_override_url,
+          value_per_click_usa,
+          value_per_click_international,
         },
       },
     } = this.props;
@@ -480,6 +484,8 @@ class EditCoursePage extends React.Component {
       enterprise_subscription_inclusion,
       organization_short_code_override,
       organization_logo_override_url,
+      value_per_click_usa,
+      value_per_click_international,
     };
   }
 


### PR DESCRIPTION
This PR allows admin users of Publisher to update value per click. The two fields, value_per_click_usa and value_per_click_international track the in-year value per click of each product.  Ultimately they get indexed into Algolia and allow Algolia to leverage this data to provide ranking of items for our users.

Jira ticket: https://2u-internal.atlassian.net/browse/WS-3203
Associated backend pr: https://github.com/openedx/course-discovery/pull/3531
Screenshot:
<img width="824" alt="Screen Shot 2022-07-26 at 3 40 51 PM" src="https://user-images.githubusercontent.com/12386424/181097904-a709ca41-0e9f-42c6-a819-578ed696cfca.png">
