### PR TITLE
WS-3120: add location restriction fields

### DIFF
--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -35,6 +35,68 @@ exports[`CreateCourseRunPage renders html correctly 1`] = `
                       },
                     ],
                   },
+                  "location_restriction": Object {
+                    "children": Object {
+                      "countries": Object {
+                        "child": Object {
+                          "choices": Array [
+                            Object {
+                              "label": "Afghanistan",
+                              "value": "AF",
+                            },
+                            Object {
+                              "label": "Åland Islands",
+                              "value": "AX",
+                            },
+                            Object {
+                              "label": "Algeria",
+                              "value": "DZ",
+                            },
+                            Object {
+                              "label": "American Samoa",
+                              "value": "AS",
+                            },
+                            Object {
+                              "label": "Andorra",
+                              "value": "AD",
+                            },
+                          ],
+                        },
+                      },
+                      "restriction_type": Object {
+                        "choices": Array [
+                          "blocklist",
+                          "allowlist",
+                        ],
+                      },
+                      "states": Object {
+                        "child": Object {
+                          "choices": Array [
+                            Object {
+                              "label": "Alabama",
+                              "value": "AL",
+                            },
+                            Object {
+                              "label": "Arizona",
+                              "value": "AZ",
+                            },
+                            Object {
+                              "label": "Arkansas",
+                              "value": "AR",
+                            },
+                            Object {
+                              "label": "California",
+                              "value": "CA",
+                            },
+                            Object {
+                              "label": "Colorado",
+                              "value": "CO",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
                   "subjects": Object {
                     "child": Object {
                       "choices": Array [
@@ -503,6 +565,68 @@ exports[`CreateCourseRunPage renders html correctly with Course Type 1`] = `
                         "value": "advanced",
                       },
                     ],
+                  },
+                  "location_restriction": Object {
+                    "children": Object {
+                      "countries": Object {
+                        "child": Object {
+                          "choices": Array [
+                            Object {
+                              "label": "Afghanistan",
+                              "value": "AF",
+                            },
+                            Object {
+                              "label": "Åland Islands",
+                              "value": "AX",
+                            },
+                            Object {
+                              "label": "Algeria",
+                              "value": "DZ",
+                            },
+                            Object {
+                              "label": "American Samoa",
+                              "value": "AS",
+                            },
+                            Object {
+                              "label": "Andorra",
+                              "value": "AD",
+                            },
+                          ],
+                        },
+                      },
+                      "restriction_type": Object {
+                        "choices": Array [
+                          "blocklist",
+                          "allowlist",
+                        ],
+                      },
+                      "states": Object {
+                        "child": Object {
+                          "choices": Array [
+                            Object {
+                              "label": "Alabama",
+                              "value": "AL",
+                            },
+                            Object {
+                              "label": "Arizona",
+                              "value": "AZ",
+                            },
+                            Object {
+                              "label": "Arkansas",
+                              "value": "AR",
+                            },
+                            Object {
+                              "label": "California",
+                              "value": "CA",
+                            },
+                            Object {
+                              "label": "Colorado",
+                              "value": "CO",
+                            },
+                          ],
+                        },
+                      },
+                    },
                   },
                   "subjects": Object {
                     "child": Object {

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -16,6 +16,9 @@ import FieldLabel from '../FieldLabel';
 import ImageUpload from '../ImageUpload';
 import RenderInputTextField from '../RenderInputTextField';
 import RenderSelectField from '../RenderSelectField';
+// TODO: remove RenderSelectFieldNew when migrating off deprecated Paragon components,
+// i.e. as a part of https://github.com/openedx/frontend-app-publisher/pull/761
+import RenderSelectFieldNew from '../RenderSelectField/updated-paragon-component';
 import RichEditor from '../RichEditor';
 import Pill from '../Pill';
 import Collapsible from '../Collapsible';
@@ -236,6 +239,12 @@ export class BaseEditCourseForm extends React.Component {
       && parseOptions(courseRunOptionsData.content_language.choices));
     const programOptions = (courseRunOptionsData
       && parseOptions(courseRunOptionsData.expected_program_type.choices));
+    const locationCountryOptions = courseOptionsData
+      && parseOptions(courseOptionsData.location_restriction.children.countries.child.choices);
+    const locationRestrictionTypeOptions = courseOptionsData
+      && parseOptions(courseOptionsData.location_restriction.children.restriction_type.choices);
+    const locationStateOptions = courseOptionsData
+      && parseOptions(courseOptionsData.location_restriction.children.states.child.choices);
 
     const {
       data: {
@@ -936,6 +945,53 @@ export class BaseEditCourseForm extends React.Component {
               optional
             />
             {administrator && (
+            <>
+              <FieldLabel text="Location Restriction" className="mb-2" />
+              <Field
+                name="location_restriction.restriction_type"
+                component={RenderSelectField}
+                label={(
+                  <FieldLabel
+                    id="location_restriction.restriction_type.label"
+                    text="Restriction Type"
+                  />
+                  )}
+                extraInput={{ onInvalid: this.openCollapsible }}
+                options={locationRestrictionTypeOptions}
+                required={false}
+                disabled={disabled}
+              />
+              <Field
+                name="location_restriction.countries"
+                component={RenderSelectFieldNew}
+                label={(
+                  <FieldLabel
+                    id="location_restriction.countries.label"
+                    text="Countries"
+                  />
+                  )}
+                extraInput={{ onInvalid: this.openCollapsible, multiple: true }}
+                options={locationCountryOptions}
+                disabled={disabled}
+                required={false}
+              />
+              <Field
+                name="location_restriction.states"
+                component={RenderSelectFieldNew}
+                label={(
+                  <FieldLabel
+                    id="location_restriction.states.label"
+                    text="States"
+                  />
+                  )}
+                extraInput={{ onInvalid: this.openCollapsible, multiple: true }}
+                options={locationStateOptions}
+                disabled={disabled}
+                required={false}
+              />
+            </>
+            )}
+            {administrator && (
               <>
                 <Field
                   name="in_year_value.per_lead_usa"
@@ -1061,6 +1117,11 @@ BaseEditCourseForm.propTypes = {
       course_type: PropTypes.string,
       organization_logo_override_url: PropTypes.string,
       organization_short_code_override: PropTypes.string,
+      location_restriction: PropTypes.shape({
+        restriction_type: PropTypes.string,
+        countries: PropTypes.arrayOf(PropTypes.string),
+        states: PropTypes.arrayOf(PropTypes.string),
+      }),
     }),
   }),
   courseSubmitInfo: PropTypes.shape({

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -34,6 +34,13 @@ describe('BaseEditCourseForm', () => {
     skill_names: [],
     organization_logo_override: 'http://image.src.small',
     organization_short_code_override: 'test short code',
+    location_restriction: {
+      restriction_type: 'allowlist',
+      countries: [
+        'AF', 'AX',
+      ],
+      states: ['CO'],
+    },
     in_year_value: {
       per_click_usa: 100,
       per_click_international: 100,

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -153,6 +153,13 @@ describe('EditCoursePage', () => {
       skill_names: [],
       organization_logo_override_url: 'http://image.src.small',
       organization_short_code_override: 'test short code',
+      location_restriction: {
+        restriction_type: 'allowlist',
+        countries: [
+          'AF', 'AX',
+        ],
+        states: ['AL'],
+      },
     },
     showCreateStatusAlert: false,
     isFetching: false,
@@ -355,6 +362,13 @@ describe('EditCoursePage', () => {
       imageSrc: 'http://image.jpg',
       learner_testimonials: '<p>I learned stuff!</p>',
       level_type: 'Basic',
+      location_restriction: {
+        restriction_type: 'allowlist',
+        countries: [
+          'AF', 'AX',
+        ],
+        states: ['AL'],
+      },
       organization_logo_override_url: 'http://image.src.small',
       organization_short_code_override: 'test short code',
       outcome: '<p>Stuff</p>',
@@ -383,6 +397,13 @@ describe('EditCoursePage', () => {
       key: 'edX+Test101x',
       learner_testimonials: '<p>I learned stuff!</p>',
       level_type: 'Basic',
+      location_restriction: {
+        restriction_type: 'allowlist',
+        countries: [
+          'AF', 'AX',
+        ],
+        states: ['AL'],
+      },
       organization_logo_override: 'http://image.src.small',
       organization_short_code_override: 'test short code',
       outcome: '<p>Stuff</p>',
@@ -905,6 +926,13 @@ describe('EditCoursePage', () => {
       key: 'edX+Test101x',
       learner_testimonials: '<p>I learned stuff!</p>',
       level_type: 'Basic',
+      location_restriction: {
+        restriction_type: 'allowlist',
+        countries: [
+          'AF', 'AX',
+        ],
+        states: ['AL'],
+      },
       organization_logo_override: 'http://image.src.small',
       organization_short_code_override: 'test short code',
       outcome: '<p>Stuff</p>',

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -1044,6 +1044,68 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
                     },
                   ],
                 },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
                 "subjects": Object {
                   "child": Object {
                     "choices": Array [
@@ -1465,6 +1527,16 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -2654,6 +2726,68 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
                     },
                   ],
                 },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
                 "subjects": Object {
                   "child": Object {
                     "choices": Array [
@@ -3075,6 +3209,16 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -3118,6 +3262,16 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -4341,6 +4495,139 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
         requiredHeight={110}
         requiredWidth={110}
       />
+      <FieldLabel
+        className="mb-2"
+        extraText=""
+        helpText=""
+        id={null}
+        optional={false}
+        text="Location Restriction"
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id="location_restriction.restriction_type.label"
+            optional={false}
+            text="Restriction Type"
+          />
+        }
+        name="location_restriction.restriction_type"
+        options={
+          Array [
+            Object {
+              "label": undefined,
+              "value": undefined,
+            },
+            Object {
+              "label": undefined,
+              "value": undefined,
+            },
+          ]
+        }
+        required={false}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "multiple": true,
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id="location_restriction.countries.label"
+            optional={false}
+            text="Countries"
+          />
+        }
+        name="location_restriction.countries"
+        options={
+          Array [
+            Object {
+              "label": undefined,
+              "value": "AF",
+            },
+            Object {
+              "label": undefined,
+              "value": "AX",
+            },
+            Object {
+              "label": undefined,
+              "value": "DZ",
+            },
+            Object {
+              "label": undefined,
+              "value": "AS",
+            },
+            Object {
+              "label": undefined,
+              "value": "AD",
+            },
+          ]
+        }
+        required={false}
+      />
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          Object {
+            "multiple": true,
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText=""
+            id="location_restriction.states.label"
+            optional={false}
+            text="States"
+          />
+        }
+        name="location_restriction.states"
+        options={
+          Array [
+            Object {
+              "label": undefined,
+              "value": "AL",
+            },
+            Object {
+              "label": undefined,
+              "value": "AZ",
+            },
+            Object {
+              "label": undefined,
+              "value": "AR",
+            },
+            Object {
+              "label": undefined,
+              "value": "CA",
+            },
+            Object {
+              "label": undefined,
+              "value": "CO",
+            },
+          ]
+        }
+        required={false}
+      />
       <Field
         component={[Function]}
         disabled={true}
@@ -4460,6 +4747,68 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {
@@ -4882,6 +5231,16 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -4925,6 +5284,16 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -6098,6 +6467,68 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
                     },
                   ],
                 },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
                 "subjects": Object {
                   "child": Object {
                     "choices": Array [
@@ -6519,6 +6950,16 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -6562,6 +7003,16 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           },
           "learner_testimonials": "learner testimonials",
           "level_type": "advanced",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "CO",
+            ],
+          },
           "organization_logo_override": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "learning outcomes",
@@ -7730,6 +8181,68 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {
@@ -9329,6 +9842,68 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -127,6 +127,11 @@ exports[`EditCoursePage renders html correctly 1`] = `
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -378,6 +383,16 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             "key": "edX+Test101x",
             "learner_testimonials": null,
             "level_type": "intermediate",
+            "location_restriction": Object {
+              "countries": Array [
+                "AF",
+                "AX",
+              ],
+              "restriction_type": "allowlist",
+              "states": Array [
+                "AL",
+              ],
+            },
             "organization_logo_override_url": "http://image.src.small",
             "organization_short_code_override": "test short code",
             "outcome": "<p>learn</p>",
@@ -592,6 +607,16 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
           },
           "learner_testimonials": null,
           "level_type": "intermediate",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "AL",
+            ],
+          },
           "organization_logo_override_url": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "<p>learn</p>",
@@ -825,6 +850,16 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             "key": "edX+Test101x",
             "learner_testimonials": null,
             "level_type": "intermediate",
+            "location_restriction": Object {
+              "countries": Array [
+                "AF",
+                "AX",
+              ],
+              "restriction_type": "allowlist",
+              "states": Array [
+                "AL",
+              ],
+            },
             "organization_logo_override_url": "http://image.src.small",
             "organization_short_code_override": "test short code",
             "outcome": "<p>learn</p>",
@@ -886,6 +921,68 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {
@@ -1322,6 +1419,16 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
           },
           "learner_testimonials": null,
           "level_type": "intermediate",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "AL",
+            ],
+          },
           "organization_logo_override_url": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "<p>learn</p>",
@@ -1493,6 +1600,11 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -1735,6 +1847,16 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             "key": "edX+Test101x",
             "learner_testimonials": null,
             "level_type": "intermediate",
+            "location_restriction": Object {
+              "countries": Array [
+                "AF",
+                "AX",
+              ],
+              "restriction_type": "allowlist",
+              "states": Array [
+                "AL",
+              ],
+            },
             "organization_logo_override_url": "http://image.src.small",
             "organization_short_code_override": "test short code",
             "outcome": "<p>learn</p>",
@@ -1796,6 +1918,68 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {
@@ -2300,6 +2484,16 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           },
           "learner_testimonials": null,
           "level_type": "intermediate",
+          "location_restriction": Object {
+            "countries": Array [
+              "AF",
+              "AX",
+            ],
+            "restriction_type": "allowlist",
+            "states": Array [
+              "AL",
+            ],
+          },
           "organization_logo_override_url": "http://image.src.small",
           "organization_short_code_override": "test short code",
           "outcome": "<p>learn</p>",
@@ -2487,6 +2681,11 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -2652,6 +2851,68 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
                       "value": "advanced",
                     },
                   ],
+                },
+                "location_restriction": Object {
+                  "children": Object {
+                    "countries": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Afghanistan",
+                            "value": "AF",
+                          },
+                          Object {
+                            "label": "Åland Islands",
+                            "value": "AX",
+                          },
+                          Object {
+                            "label": "Algeria",
+                            "value": "DZ",
+                          },
+                          Object {
+                            "label": "American Samoa",
+                            "value": "AS",
+                          },
+                          Object {
+                            "label": "Andorra",
+                            "value": "AD",
+                          },
+                        ],
+                      },
+                    },
+                    "restriction_type": Object {
+                      "choices": Array [
+                        "blocklist",
+                        "allowlist",
+                      ],
+                    },
+                    "states": Object {
+                      "child": Object {
+                        "choices": Array [
+                          Object {
+                            "label": "Alabama",
+                            "value": "AL",
+                          },
+                          Object {
+                            "label": "Arizona",
+                            "value": "AZ",
+                          },
+                          Object {
+                            "label": "Arkansas",
+                            "value": "AR",
+                          },
+                          Object {
+                            "label": "California",
+                            "value": "CA",
+                          },
+                          Object {
+                            "label": "Colorado",
+                            "value": "CO",
+                          },
+                        ],
+                      },
+                    },
+                  },
                 },
                 "subjects": Object {
                   "child": Object {
@@ -2950,6 +3211,11 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -3119,6 +3385,11 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -3363,6 +3634,11 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,
@@ -3532,6 +3808,11 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
           },
           "learner_testimonials": undefined,
           "level_type": undefined,
+          "location_restriction": Object {
+            "countries": null,
+            "restriction_type": null,
+            "states": null,
+          },
           "organization_logo_override_url": undefined,
           "organization_short_code_override": undefined,
           "outcome": undefined,

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -210,6 +210,21 @@ class EditCoursePage extends React.Component {
     };
   }
 
+  formatLocationRestrictionFields(courseData) {
+    if (courseData?.location_restriction) {
+      return {
+        restriction_type: courseData.location_restriction.restriction_type,
+        countries: courseData.location_restriction.countries,
+        states: courseData.location_restriction.states,
+      };
+    }
+    return {
+      restriction_type: null,
+      countries: null,
+      states: null,
+    };
+  }
+
   prepareSendCourseData(courseData) {
     const {
       courseInfo: {
@@ -236,6 +251,7 @@ class EditCoursePage extends React.Component {
       key,
       learner_testimonials: courseData.learner_testimonials,
       level_type: courseData.level_type,
+      location_restriction: courseData.location_restriction,
       organization_logo_override: courseData.organization_logo_override_url,
       organization_short_code_override: courseData.organization_short_code_override,
       outcome: courseData.outcome,
@@ -262,10 +278,12 @@ class EditCoursePage extends React.Component {
     if (courseData.course_type === EXECUTIVE_EDUCATION_SLUG) {
       formattedCourseData.additional_metadata = this.formatAdditionalMetadataFields(courseData);
     }
+
     // Check for values to prevent a new entry being created unnecessarily
     if (courseData.in_year_value && Object.values(courseData.in_year_value).some(value => value !== null)) {
       formattedCourseData.in_year_value = this.formatValueFields(courseData);
     }
+
     return formattedCourseData;
   }
 
@@ -441,6 +459,10 @@ class EditCoursePage extends React.Component {
     return this.formatValueFields(this.props.courseInfo.data);
   }
 
+  buildLocationRestriction() {
+    return this.formatLocationRestrictionFields(this.props.courseInfo.data);
+  }
+
   buildInitialValues() {
     const {
       courseInfo: {
@@ -506,6 +528,7 @@ class EditCoursePage extends React.Component {
       enterprise_subscription_inclusion,
       organization_short_code_override,
       organization_logo_override_url,
+      location_restriction: this.buildLocationRestriction(),
       in_year_value: this.buildInYearValue(),
     };
   }

--- a/src/components/RenderSelectField/updated-paragon-component.jsx
+++ b/src/components/RenderSelectField/updated-paragon-component.jsx
@@ -1,0 +1,71 @@
+// TODO: This file can be deleted as a part of https://github.com/openedx/frontend-app-publisher/pull/761
+// When we migrate off deprecated paragon components, we want to replace the contents of ./index.jsx
+// with the contents of this file and then delete this file.
+// Adding this file to the codebase as a temporary measure
+// because the existing select component doesn't have multiselect functionality
+// and it doesn't make sense to edit paragon to add that functionality bc we're moving off that component soon.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form } from '@edx/paragon';
+
+const RenderSelectField = ({
+  input,
+  extraInput,
+  name,
+  label,
+  disabled,
+  required,
+  meta: { touched, error },
+  options,
+}) => (
+  <Form.Group controlId={`${name}-text-label`} isInvalid={touched && error}>
+    <Form.Label>
+      {label}
+    </Form.Label>
+    <Form.Control
+      {...input}
+      {...extraInput}
+      as="select"
+      name={name}
+      label={label}
+      disabled={disabled}
+      required={required}
+    >
+      {options.map(option => (
+        <option key={option.value} value={option.value}>{option.label}</option>
+      ))}
+      {touched && error && (
+      <Form.Control.Feedback>
+        {error}
+      </Form.Control.Feedback>
+      )}
+    </Form.Control>
+  </Form.Group>
+);
+
+RenderSelectField.defaultProps = {
+  extraInput: {},
+  name: '',
+  disabled: false,
+  required: false,
+};
+
+RenderSelectField.propTypes = {
+  input: PropTypes.shape({}).isRequired,
+  extraInput: PropTypes.shape({}),
+  name: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  meta: PropTypes.shape({
+    touched: PropTypes.bool,
+    error: PropTypes.string,
+  }).isRequired,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  options: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.object),
+  ]).isRequired,
+};
+
+export default RenderSelectField;

--- a/src/data/constants/testData.js
+++ b/src/data/constants/testData.js
@@ -225,6 +225,38 @@ const courseOptions = {
             ],
           },
         },
+        location_restriction: {
+          children: {
+            restriction_type: {
+              choices: [
+                'blocklist',
+                'allowlist',
+              ],
+            },
+            countries: {
+              child: {
+                choices: [
+                  { label: 'Afghanistan', value: 'AF' },
+                  { label: 'Åland Islands', value: 'AX' },
+                  { label: 'Algeria', value: 'DZ' },
+                  { label: 'American Samoa', value: 'AS' },
+                  { label: 'Andorra', value: 'AD' },
+                ],
+              },
+            },
+            states: {
+              child: {
+                choices: [
+                  { label: 'Alabama', value: 'AL' },
+                  { label: 'Arizona', value: 'AZ' },
+                  { label: 'Arkansas', value: 'AR' },
+                  { label: 'California', value: 'CA' },
+                  { label: 'Colorado', value: 'CO' },
+                ],
+              },
+            },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
This PR adds the location restriction fields `restriction_type`, `countries` and `states`. All field options come from course discovery.

These fields specify the regions for which a course will be made available.

~~
Note: I pulled in the most up-to-date react select component to use for these new fields. This is because the existing InputSelect doesn't have a multiselect option.  I had made a PR to add multiselect functionality to InputSelect but realized that we will be moving off InputSelect in Publisher soon.

So this PR puts the code in an interim state where there are *two* versions of the select component - the soon-to-be-deprecated InputSelect that we are using across Publisher and a new paragon component that I've added for the location restriction fields only. However [this PR](https://github.com/openedx/frontend-app-publisher/pull/761/files) will move all of Publisher to the new components and I think we should reduce the two select components to one as a part of that work.

~~

<img width="522" alt="Screen Shot 2022-08-11 at 2 36 42 PM" src="https://user-images.githubusercontent.com/12386424/184218239-6a6034cd-cc5e-4cf6-817d-84cecbc9cf26.png">
