### PR TITLE
feat: add variant_id to publisher UI for exec ed courses

### DIFF
--- a/src/components/EditCoursePage/AdditionalMetadataFields.jsx
+++ b/src/components/EditCoursePage/AdditionalMetadataFields.jsx
@@ -44,6 +44,13 @@ function AdditionalMetadataFields(props) {
           disabled={disabled}
           required
         />
+        <Field
+          name="additional_metadata.variant_id"
+          component={RenderInputTextField}
+          label=<FieldLabel id="variant_id.label" text="Course Variant Id" />
+          disabled={disabled}
+          required
+        />
         <FieldLabel text="Fact 1" className="h3 font-weight-normal" />
         <Field
           name="additional_metadata.facts_1_heading"

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -47,6 +47,7 @@ describe('EditCoursePage', () => {
         }],
         start_date: '2019-05-10T00:00:00Z',
         registration_deadline: '2019-05-10T00:00:00Z',
+        variant_id: '00000000-0000-0000-0000-000000000000',
       },
       course_runs: [
         {
@@ -348,6 +349,7 @@ describe('EditCoursePage', () => {
         facts_2_blurb: 'facts_2_blurb',
         start_date: '2019-05-10T00:00:00Z',
         registration_deadline: '2019-05-10T00:00:00Z',
+        variant_id: '00000000-0000-0000-0000-000000000000',
       },
       course_runs: [unpublishedCourseRun, publishedCourseRun],
       faq: '<p>Help?</p>',
@@ -896,6 +898,7 @@ describe('EditCoursePage', () => {
         }],
         start_date: '2019-05-10T00:00:00Z',
         registration_deadline: '2019-05-10T00:00:00Z',
+        variant_id: '00000000-0000-0000-0000-000000000000',
       },
       draft: false,
       collaborators: undefined,

--- a/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/AdditionalMetadataFields.test.jsx.snap
@@ -79,6 +79,22 @@ exports[`AdditionalMetadata Fields Display all fields 1`] = `
       name="additional_metadata.organic_url"
       required={true}
     />
+    <Field
+      component={[Function]}
+      disabled={false}
+      label={
+        <FieldLabel
+          className=""
+          extraText=""
+          helpText=""
+          id="variant_id.label"
+          optional={false}
+          text="Course Variant Id"
+        />
+      }
+      name="additional_metadata.variant_id"
+      required={true}
+    />
     <FieldLabel
       className="h3 font-weight-normal"
       extraText=""

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -302,6 +302,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
               "organic_url": "https://www.organic_url.com",
               "registration_deadline": "2019-05-10T00:00:00Z",
               "start_date": "2019-05-10T00:00:00Z",
+              "variant_id": "00000000-0000-0000-0000-000000000000",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -523,6 +524,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             "organic_url": "https://www.organic_url.com",
             "registration_deadline": "2019-05-10T00:00:00Z",
             "start_date": "2019-05-10T00:00:00Z",
+            "variant_id": "00000000-0000-0000-0000-000000000000",
           },
           "collaborators": Array [],
           "course_runs": Array [
@@ -749,6 +751,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
               "organic_url": "https://www.organic_url.com",
               "registration_deadline": "2019-05-10T00:00:00Z",
               "start_date": "2019-05-10T00:00:00Z",
+              "variant_id": "00000000-0000-0000-0000-000000000000",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -1253,6 +1256,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             "organic_url": "https://www.organic_url.com",
             "registration_deadline": "2019-05-10T00:00:00Z",
             "start_date": "2019-05-10T00:00:00Z",
+            "variant_id": "00000000-0000-0000-0000-000000000000",
           },
           "collaborators": Array [],
           "course_runs": Array [
@@ -1659,6 +1663,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
               "organic_url": "https://www.organic_url.com",
               "registration_deadline": "2019-05-10T00:00:00Z",
               "start_date": "2019-05-10T00:00:00Z",
+              "variant_id": "00000000-0000-0000-0000-000000000000",
             },
             "collaborators": Array [],
             "course_runs": Array [
@@ -2231,6 +2236,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             "organic_url": "https://www.organic_url.com",
             "registration_deadline": "2019-05-10T00:00:00Z",
             "start_date": "2019-05-10T00:00:00Z",
+            "variant_id": "00000000-0000-0000-0000-000000000000",
           },
           "collaborators": Array [],
           "course_runs": Array [

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -190,6 +190,7 @@ class EditCoursePage extends React.Component {
       }],
       start_date: courseData.additional_metadata.start_date,
       registration_deadline: courseData.additional_metadata.registration_deadline,
+      variant_id: courseData.additional_metadata.variant_id,
     };
   }
 
@@ -380,6 +381,7 @@ class EditCoursePage extends React.Component {
         facts_2_blurb: additional_metadata.facts[1]?.blurb,
         start_date: additional_metadata.start_date,
         registration_deadline: additional_metadata.registration_deadline,
+        variant_id: additional_metadata.variant_id,
       };
     }
     return {};


### PR DESCRIPTION
Add variant_id to publisher UI, now that it exists as a field within the discovery service

<img width="656" alt="Screen Shot 2022-08-11 at 5 35 21 PM" src="https://user-images.githubusercontent.com/7385292/184246488-f2bed557-36ba-4f50-82e0-b3a73daee76a.png">
