### PR TITLE
fix: tinymce css loading fixup

### DIFF
--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -21,6 +21,8 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
       init={
         Object {
           "branding": false,
+          "content_css": false,
+          "content_style": "",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
@@ -65,6 +67,8 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
       init={
         Object {
           "branding": false,
+          "content_css": false,
+          "content_style": "",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
@@ -107,6 +111,8 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
       init={
         Object {
           "branding": false,
+          "content_css": false,
+          "content_style": "",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
@@ -151,6 +157,8 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
       init={
         Object {
           "branding": false,
+          "content_css": false,
+          "content_style": "",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -9,8 +9,10 @@ import 'tinymce/plugins/legacyoutput';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/themes/silver/theme';
-import 'style-loader!tinymce/skins/ui/oxide/skin.min.css'; // eslint-disable-line import/no-webpack-loader-syntax, import/no-unresolved
 import '@edx/tinymce-language-selector';
+import 'tinymce/skins/ui/oxide/skin.css';
+import contentCss from 'tinymce/skins/content/default/content.min.css';
+import contentUiCss from 'tinymce/skins/ui/oxide/content.min.css';
 import StatusAlert from '../StatusAlert';
 
 class RichEditor extends React.Component {
@@ -58,6 +60,14 @@ class RichEditor extends React.Component {
     const characterLimitMessage = `Recommended character limit (including spaces) is
       ${maxChars}. ${remainingChars} characters remaining.`;
 
+    let contentStyle;
+    // In the test environment this causes an error so set styles to empty since they aren't needed for testing.
+    try {
+      contentStyle = [contentCss, contentUiCss].join('\n');
+    } catch (err) {
+      contentStyle = '';
+    }
+
     return (
       <div className="form-group">
         <div id={id} name={name} tabIndex="-1" className="mb-2">{label}</div>
@@ -86,6 +96,8 @@ class RichEditor extends React.Component {
               toolbar: 'undo redo | bold italic underline | bullist numlist | link | language',
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
+              content_css: false,
+              content_style: contentStyle,
             }}
             onChange={this.updateCharCount}
             onKeyUp={this.updateCharCount}


### PR DESCRIPTION
### [PROD-2907](https://2u-internal.atlassian.net/browse/PROD-2907)

### Description
Fix the loading of content and skin css files for tinymce editor. The incorrect import was causing styles to not apply as expected, causing issues for dialog/pop-up behavior.

### References
- https://github.com/openedx/frontend-app-discussions/blob/b15fd961085d987157ea15001a0b8e504c7a4dc7/src/components/TinyMCEEditor.jsx
- https://www.tiny.cloud/docs/advanced/usage-with-module-loaders/webpack/webpack_es6_npm/
- https://www.tiny.cloud/docs/advanced/usage-with-module-loaders/reference/content-css/
- https://www.tiny.cloud/docs-3x/reference/Configuration3x/Configuration3x@content_css/

### Testing
- Run publisher on your local on master.
- Run npm install to have updated reqs
- Open any course for editing. Try edit link or change browser default language for any markdown editor field
- You will notice the issue as shown in **Before** section of screenshots
- Check out PR branch on local.
- Clear the browser cache and do the edit link again. You will see the dialog is rendering correctly

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/40599381/184338120-63d86227-e694-4065-8ae4-ee98b32ec494.png)

#### After
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/40599381/184338019-199ce698-b096-4ce4-ab24-9fe7555f1263.png">

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/40599381/184338065-457b89b2-f43a-4955-bf28-88432cf79b2f.png">
