### PR TITLE
refactor: reduce SCSS

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,12 +1,9 @@
 .site-header {
-  border-bottom: 1px solid $gray-300;
-
   .navbar-brand {
     max-width: 100px;
   }
-}
 
-.disabled-link {
-  pointer-events: none;
-  color: $gray-300;
+  .disabled-link {
+    pointer-events: none;
+  }
 }

--- a/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header renders the correct header 1`] = `
 <header
-  className="site-header mb-3 py-3 border-bottom-blue"
+  className="site-header mb-3 py-3 border-bottom border-gray-300"
 >
   <div
     className="container"
@@ -237,7 +237,7 @@ exports[`Header renders the correct header 1`] = `
 
 exports[`Header renders the header correctly when toggling is allowed, and dark mode is on 1`] = `
 <header
-  className="site-header mb-3 py-3 border-bottom-blue"
+  className="site-header mb-3 py-3 border-bottom border-gray-300"
 >
   <div
     className="container"
@@ -484,7 +484,7 @@ exports[`Header renders the header correctly when toggling is allowed, and dark 
 
 exports[`Header renders the header correctly when users pass a querystring param to allow dark mode toggling 1`] = `
 <header
-  className="site-header mb-3 py-3 border-bottom-blue"
+  className="site-header mb-3 py-3 border-bottom border-gray-300"
 >
   <div
     className="container"

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -24,11 +24,11 @@ const Header = ({ darkModeOn, location, toggleDarkMode }) => {
 
   function disableLink(courseType) {
     const courseTypeFromURL = querystringParams.course_type ? querystringParams.course_type : '';
-    return (courseTypeFromURL === courseType && pathname === '/') ? 'disabled-link' : '';
+    return (courseTypeFromURL === courseType && pathname === '/') ? 'disabled-link text-gray-300' : '';
   }
 
   return (
-    <header className="site-header mb-3 py-3 border-bottom-blue">
+    <header className="site-header mb-3 py-3 border-bottom border-gray-300">
       <div className="container">
         <div className="row align-items-center">
           <div className="col-auto justify-content-start">

--- a/src/components/ListField/ListField.scss
+++ b/src/components/ListField/ListField.scss
@@ -1,21 +1,9 @@
-.react-autosuggest__container {
-  position: relative;
-}
-
-.react-autosuggest__suggestions-container {
-  display: none;
-  width: 100%;
-}
-
 .react-autosuggest__suggestions-container--open {
-  display: block;
   position: absolute;
   top: 29px;
-  width: 100%;
-  border: 1px solid $gray-300;
+  border: 1px solid;
   margin-top: 12px;
   z-index: 2;
-  background-color: $white;
   border-bottom: {
     left-radius: 0.1875rem;
     right-radius: 0.1875rem;
@@ -23,13 +11,5 @@
 }
 
 .react-autosuggest__suggestions-list {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
   max-height: 318px;
-  overflow-y: auto;
-}
-
-.react-autosuggest__suggestion--highlighted {
-  background-color: $gray-300;
 }

--- a/src/components/ListField/ListField.scss
+++ b/src/components/ListField/ListField.scss
@@ -2,25 +2,6 @@
   position: relative;
 }
 
-.react-autosuggest__input {
-  width: 100%;
-  height: 30px;
-  padding: 10px 20px;
-  border: 1px solid $gray-600;
-  border-radius: 0.1875rem;
-}
-
-.react-autosuggest__input--focused {
-  outline: none;
-}
-
-.react-autosuggest__input--open {
-  border-bottom: {
-    left-radius: 0;
-    right-radius: 0;
-  }
-}
-
 .react-autosuggest__suggestions-container {
   display: none;
   width: 100%;

--- a/src/components/ListField/__snapshots__/ListField.test.jsx.snap
+++ b/src/components/ListField/__snapshots__/ListField.test.jsx.snap
@@ -58,20 +58,10 @@ exports[`ListField - Collaborators renders a list of item members and an autocom
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />
@@ -161,20 +151,10 @@ exports[`ListField - Collaborators renders correctly with an error after failed 
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />
@@ -240,20 +220,10 @@ exports[`ListField - Collaborators renders correctly with referred props 1`] = `
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />
@@ -318,20 +288,10 @@ exports[`ListField - Staffers renders a list of staff members and an autocomplet
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />
@@ -420,20 +380,10 @@ exports[`ListField - Staffers renders correctly with an error after failed submi
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />
@@ -498,20 +448,10 @@ exports[`ListField - Staffers renders correctly with referred props 1`] = `
       suggestions={Array []}
       theme={
         Object {
-          "container": "react-autosuggest__container",
-          "containerOpen": "react-autosuggest__container--open",
-          "input": "react-autosuggest__input",
-          "inputFocused": "react-autosuggest__input--focused",
-          "inputOpen": "react-autosuggest__input--open",
-          "sectionContainer": "react-autosuggest__section-container",
-          "sectionContainerFirst": "react-autosuggest__section-container--first",
-          "sectionTitle": "react-autosuggest__section-title",
-          "suggestion": "react-autosuggest__suggestion",
-          "suggestionFirst": "react-autosuggest__suggestion--first",
-          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
-          "suggestionsContainer": "react-autosuggest__suggestions-container",
-          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
-          "suggestionsList": "react-autosuggest__suggestions-list",
+          "container": "react-autosuggest__container position-relative",
+          "suggestionHighlighted": "react-autosuggest__suggestion--highlighted bg-gray-300",
+          "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100",
+          "suggestionsList": "react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto",
         }
       }
     />

--- a/src/components/ListField/index.jsx
+++ b/src/components/ListField/index.jsx
@@ -235,6 +235,12 @@ class ListField extends React.Component {
             onSuggestionSelected={this.onSuggestionEntered}
             alwaysRenderSuggestions={searchString.length > 2}
             id={`${itemType}-search`}
+            theme={{
+              container: 'react-autosuggest__container position-relative',
+              suggestionsContainerOpen: 'react-autosuggest__suggestions-container--open bg-white border-gray-300 w-100',
+              suggestionsList: 'react-autosuggest__suggestions-list m-0 p-0 list-unstyled overflow-auto',
+              suggestionHighlighted: 'react-autosuggest__suggestion--highlighted bg-gray-300',
+            }}
           />
         </label>
         {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */}


### PR DESCRIPTION
## Description

Reduces the amount of SCSS in the repo, by applying the styling using bootstrap classes wherever possible.

The main goal is to reduce number of instances where bootstrap variables are used in custom styles, and replace them by applying bootstrap classes directly on the elements. E.g. removing style `color: $gray-300;`, and adding `text-gray-300` class to disabled links in the header.

The secondary goals are to remove unused styles (i.e. styles that don't have any effect) and remove custom styles that can be replaced by bootstrap classes.

## Testing instructions

### General setup

* Setup local `master` devstack
* Checkout the branch in `frontend-app-publisher`
* Run `make frontend-app-publisher-up studio-up` to spin up necessary containers
* Go to `localhost:18000` and sign in
* Go to `localhost:18400`
* Create a new course

### Testing autosuggest drop down

* From `localhost:18400` navigate to the course you've created
* Open up course information
* Scroll down to `Search or add new collaborator:`
* Start typing until you see a suggestion drop down show up
* Create a new collaborator
* Remove it from the course and make the drop down appear again
* Make sure the drop down looks the same as before the modifications

### Testing header

* Go to `localhost:18400`
* Make sure the header looks the same as before
* Apply the following patch to force the links in the headers to appear disabled:
```diff
diff --git a/src/components/Header/index.jsx b/src/components/Header/index.jsx
index 2cdd111..03a2ab7 100644
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -24,7 +24,8 @@ const Header = ({ darkModeOn, location, toggleDarkMode }) => {

   function disableLink(courseType) {
     const courseTypeFromURL = querystringParams.course_type ? querystringParams.course_type : '';
-    return (courseTypeFromURL === courseType && pathname === '/') ? 'disabled-link text-gray-300' : '';
+    return 'disabled-link text-gray-300';
+    // return (courseTypeFromURL === courseType && pathname === '/') ? 'disabled-link text-gray-300' : '';
   }

   return (
```
* Compare that disabled links look the same as before

## Other information

### Gray out text area in disabled RichEditor editor

Couldn't remove custom style in file [`src/components/RichEditor/RichEditor.scss`](https://github.com/open-craft/frontend-app-publisher/blob/40a1e3b3cb23cf271d35c4fbeb14bbd0b662023a/src/components/RichEditor/RichEditor.scss) which is using a boostrap variable:
```scss
.disabled-rich-text .tox .tox-edit-area__iframe {
  background-color: $input-disabled-bg;
}
```
This style is applied to the `iframe` wrapper element inside of the `TinyMCE` editor to make the text field appear gray when the editor is in disabled state. I wasn't able to find a way to pass a class name to `TinyMCE` editor which it would apply to the `iframe` wrapper. I also wasn't able to find a way to replicate the same behavior without using the bootstrap variable or hard-coding the color value.

### Removed `.react-autosuggest__input` class

Were able to remove `.react-autosuggest__input` class, because it is not applied to the input element. Instead this element has class `.form-control`, because it's overwritten by `inputProps` in `src/components/ListField/index.jsx` on lines 183 and 236.

In other words, these styles are never used, so removing them.

## Private references

`Private-ref`: [BB-6217](https://tasks.opencraft.com/browse/BB-6217)