### PR TITLE
chore: change Emsi to Lightcast in Skills tooltip

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -1030,7 +1030,7 @@ export class BaseEditCourseForm extends React.Component {
                     helpText={(
                       <div>
                         <p>
-                          edX partners with Emsi, the labor market data company,
+                          edX partners with Lightcast, the labor market data company,
                           to automatically tag your courses with in-demand
                           skills from their library of 30,000 skills based on
                           the content in your about page. If you want to

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -9938,7 +9938,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
             helpText={
               <div>
                 <p>
-                  edX partners with Emsi, the labor market data company, to automatically tag your courses with in-demand skills from their library of 30,000 skills based on the content in your about page. If you want to experiment with what skills show up, you can edit and submit changes to your about page description.
+                  edX partners with Lightcast, the labor market data company, to automatically tag your courses with in-demand skills from their library of 30,000 skills based on the content in your about page. If you want to experiment with what skills show up, you can edit and submit changes to your about page description.
                 </p>
               </div>
             }


### PR DESCRIPTION
## Description
Changing the Emsi name to Lightcast in Skills tooltip because now Emsi is branded as Lightcast. 

Jira: [ENT-6287](https://2u-internal.atlassian.net/browse/ENT-6287)