### PR TITLE
refactor: minor UI updates

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 NODE_ENV='development'
 PORT=18400
-BASE_URL='localhost:18400'
+BASE_URL='http://localhost:18400'
 LMS_BASE_URL='http://localhost:18000'
 STUDIO_BASE_URL='http://localhost:18010'
 DISCOVERY_API_BASE_URL='http://localhost:18381'

--- a/src/components/CourseTable/CourseTable.scss
+++ b/src/components/CourseTable/CourseTable.scss
@@ -1,0 +1,6 @@
+.width-percent-44{
+    width: 44%;
+}
+.width-percent-12{
+    width: 12%;
+}

--- a/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
+++ b/src/components/CourseTable/__snapshots__/CourseTable.test.jsx.snap
@@ -22,26 +22,7 @@ exports[`CourseTable displays table and button when not blacklisted 1`] = `
     className="row"
   >
     <div
-      className="col-2 float-left"
-    >
-      <ButtonToolbar
-        className="mb-3"
-        leftJustify={true}
-      >
-        <Link
-          to="/courses/new"
-        >
-          <button
-            className="btn btn-primary"
-            type="button"
-          >
-            New Course
-          </button>
-        </Link>
-      </ButtonToolbar>
-    </div>
-    <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <StateManager
         closeMenuOnSelect={false}
@@ -92,7 +73,7 @@ exports[`CourseTable displays table and button when not blacklisted 1`] = `
       />
     </div>
     <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <SearchField
         buttonText="search"
@@ -126,19 +107,39 @@ exports[`CourseTable displays table and button when not blacklisted 1`] = `
         variant="light"
       />
     </div>
+    <div
+      className="width-percent-12 px-3 float-right"
+    >
+      <ButtonToolbar
+        className="mb-3"
+        leftJustify={false}
+        rightJustify={true}
+      >
+        <Link
+          to="/courses/new"
+        >
+          <button
+            className="btn btn-primary"
+            type="button"
+          >
+            New course
+          </button>
+        </Link>
+      </ButtonToolbar>
+    </div>
   </div>
   <withRouter(Connect(TableComponent))
     className="courses"
     columns={
       Array [
         Object {
-          "Header": "Course Name",
+          "Header": "Course name",
           "accessor": "title",
           "disableSortBy": false,
           "key": "title",
         },
         Object {
-          "Header": "Course Number",
+          "Header": "Course number",
           "accessor": "number",
           "disableSortBy": false,
           "key": "number",
@@ -150,7 +151,7 @@ exports[`CourseTable displays table and button when not blacklisted 1`] = `
           "key": "course_run_statuses",
         },
         Object {
-          "Header": "Course Editors",
+          "Header": "Course editors",
           "accessor": "course_editor_names",
           "disableSortBy": true,
           "key": "course_editor_names",
@@ -185,26 +186,7 @@ exports[`CourseTable displays table and button when user has no orgs 1`] = `
     className="row"
   >
     <div
-      className="col-2 float-left"
-    >
-      <ButtonToolbar
-        className="mb-3"
-        leftJustify={true}
-      >
-        <Link
-          to="/courses/new"
-        >
-          <button
-            className="btn btn-primary"
-            type="button"
-          >
-            New Course
-          </button>
-        </Link>
-      </ButtonToolbar>
-    </div>
-    <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <StateManager
         closeMenuOnSelect={false}
@@ -255,7 +237,7 @@ exports[`CourseTable displays table and button when user has no orgs 1`] = `
       />
     </div>
     <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <SearchField
         buttonText="search"
@@ -289,19 +271,39 @@ exports[`CourseTable displays table and button when user has no orgs 1`] = `
         variant="light"
       />
     </div>
+    <div
+      className="width-percent-12 px-3 float-right"
+    >
+      <ButtonToolbar
+        className="mb-3"
+        leftJustify={false}
+        rightJustify={true}
+      >
+        <Link
+          to="/courses/new"
+        >
+          <button
+            className="btn btn-primary"
+            type="button"
+          >
+            New course
+          </button>
+        </Link>
+      </ButtonToolbar>
+    </div>
   </div>
   <withRouter(Connect(TableComponent))
     className="courses"
     columns={
       Array [
         Object {
-          "Header": "Course Name",
+          "Header": "Course name",
           "accessor": "title",
           "disableSortBy": false,
           "key": "title",
         },
         Object {
-          "Header": "Course Number",
+          "Header": "Course number",
           "accessor": "number",
           "disableSortBy": false,
           "key": "number",
@@ -313,7 +315,7 @@ exports[`CourseTable displays table and button when user has no orgs 1`] = `
           "key": "course_run_statuses",
         },
         Object {
-          "Header": "Course Editors",
+          "Header": "Course editors",
           "accessor": "course_editor_names",
           "disableSortBy": true,
           "key": "course_editor_names",
@@ -348,26 +350,7 @@ exports[`CourseTable hides table and button when blacklisted 1`] = `
     className="row"
   >
     <div
-      className="col-2 float-left"
-    >
-      <ButtonToolbar
-        className="mb-3"
-        leftJustify={true}
-      >
-        <Link
-          to="/courses/new"
-        >
-          <button
-            className="btn btn-primary"
-            type="button"
-          >
-            New Course
-          </button>
-        </Link>
-      </ButtonToolbar>
-    </div>
-    <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <StateManager
         closeMenuOnSelect={false}
@@ -418,7 +401,7 @@ exports[`CourseTable hides table and button when blacklisted 1`] = `
       />
     </div>
     <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <SearchField
         buttonText="search"
@@ -452,19 +435,39 @@ exports[`CourseTable hides table and button when blacklisted 1`] = `
         variant="light"
       />
     </div>
+    <div
+      className="width-percent-12 px-3 float-right"
+    >
+      <ButtonToolbar
+        className="mb-3"
+        leftJustify={false}
+        rightJustify={true}
+      >
+        <Link
+          to="/courses/new"
+        >
+          <button
+            className="btn btn-primary"
+            type="button"
+          >
+            New course
+          </button>
+        </Link>
+      </ButtonToolbar>
+    </div>
   </div>
   <withRouter(Connect(TableComponent))
     className="courses"
     columns={
       Array [
         Object {
-          "Header": "Course Name",
+          "Header": "Course name",
           "accessor": "title",
           "disableSortBy": false,
           "key": "title",
         },
         Object {
-          "Header": "Course Number",
+          "Header": "Course number",
           "accessor": "number",
           "disableSortBy": false,
           "key": "number",
@@ -476,7 +479,7 @@ exports[`CourseTable hides table and button when blacklisted 1`] = `
           "key": "course_run_statuses",
         },
         Object {
-          "Header": "Course Editors",
+          "Header": "Course editors",
           "accessor": "course_editor_names",
           "disableSortBy": true,
           "key": "course_editor_names",
@@ -511,26 +514,7 @@ exports[`CourseTable shows a table 1`] = `
     className="row"
   >
     <div
-      className="col-2 float-left"
-    >
-      <ButtonToolbar
-        className="mb-3"
-        leftJustify={true}
-      >
-        <Link
-          to="/courses/new"
-        >
-          <button
-            className="btn btn-primary"
-            type="button"
-          >
-            New Course
-          </button>
-        </Link>
-      </ButtonToolbar>
-    </div>
-    <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <StateManager
         closeMenuOnSelect={false}
@@ -581,7 +565,7 @@ exports[`CourseTable shows a table 1`] = `
       />
     </div>
     <div
-      className="col-5 float-right"
+      className="width-percent-44 px-3 float-left"
     >
       <SearchField
         buttonText="search"
@@ -615,19 +599,39 @@ exports[`CourseTable shows a table 1`] = `
         variant="light"
       />
     </div>
+    <div
+      className="width-percent-12 px-3 float-right"
+    >
+      <ButtonToolbar
+        className="mb-3"
+        leftJustify={false}
+        rightJustify={true}
+      >
+        <Link
+          to="/courses/new"
+        >
+          <button
+            className="btn btn-primary"
+            type="button"
+          >
+            New course
+          </button>
+        </Link>
+      </ButtonToolbar>
+    </div>
   </div>
   <withRouter(Connect(TableComponent))
     className="courses"
     columns={
       Array [
         Object {
-          "Header": "Course Name",
+          "Header": "Course name",
           "accessor": "title",
           "disableSortBy": false,
           "key": "title",
         },
         Object {
-          "Header": "Course Number",
+          "Header": "Course number",
           "accessor": "number",
           "disableSortBy": false,
           "key": "number",
@@ -639,7 +643,7 @@ exports[`CourseTable shows a table 1`] = `
           "key": "course_run_statuses",
         },
         Object {
-          "Header": "Course Editors",
+          "Header": "Course editors",
           "accessor": "course_editor_names",
           "disableSortBy": true,
           "key": "course_editor_names",

--- a/src/components/CourseTable/index.jsx
+++ b/src/components/CourseTable/index.jsx
@@ -15,6 +15,8 @@ import { formatDate, getPageOptionsFromUrl, updateUrl } from '../../utils';
 import Pill from '../Pill';
 import { PUBLISHED, REVIEWED } from '../../data/constants';
 
+import './CourseTable.scss';
+
 const dot = color => ({
   alignItems: 'center',
   display: 'flex',
@@ -133,14 +135,7 @@ class CourseTable extends React.Component {
     return (
       <>
         <div className="row">
-          <div className="col-2 float-left">
-            <ButtonToolbar className="mb-3" leftJustify>
-              <Link to="/courses/new">
-                <button type="button" className="btn btn-primary">New Course</button>
-              </Link>
-            </ButtonToolbar>
-          </div>
-          <div className="col-5 float-right">
+          <div className="width-percent-44 px-3 float-left">
             <Select
               closeMenuOnSelect={false}
               value={selectedFilters}
@@ -166,7 +161,7 @@ class CourseTable extends React.Component {
               }
             />
           </div>
-          <div className="col-5 float-right">
+          <div className="width-percent-44 px-3 float-left">
             <SearchField
               value={pageOptions.pubq}
               onClear={() => {
@@ -177,6 +172,13 @@ class CourseTable extends React.Component {
               }}
               placeholder="Search"
             />
+          </div>
+          <div className="width-percent-12 px-3 float-right">
+            <ButtonToolbar className="mb-3" rightJustify>
+              <Link to="/courses/new">
+                <button type="button" className="btn btn-primary">New course</button>
+              </Link>
+            </ButtonToolbar>
           </div>
         </div>
       </>
@@ -193,13 +195,13 @@ class CourseTable extends React.Component {
 
     const courseTableColumns = [
       {
-        Header: 'Course Name',
+        Header: 'Course name',
         key: 'title',
         disableSortBy: false,
         accessor: 'title',
       },
       {
-        Header: 'Course Number',
+        Header: 'Course number',
         key: 'number',
         disableSortBy: false,
         accessor: 'number',
@@ -211,7 +213,7 @@ class CourseTable extends React.Component {
         disableSortBy: true,
       },
       {
-        Header: 'Course Editors',
+        Header: 'Course editors',
         key: 'course_editor_names',
         accessor: 'course_editor_names',
         disableSortBy: true,

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -79,6 +79,7 @@ const formatCourseRunTitle = (courseRun, copied, setCopied) => {
             <Hyperlink
               destination={`${getConfig().STUDIO_BASE_URL}/course/${courseRun.key}`}
               target="_blank"
+              isInline
             >
               {courseRun.key}
             </Hyperlink>
@@ -277,7 +278,7 @@ class CollapsibleCourseRun extends React.Component {
         onToggle={onToggle}
       >
         <div className="mb-3">
-          <span className="text-info" aria-hidden> All fields are required for publication unless otherwise specified.</span>
+          <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
         </div>
         {/* TODO this should be refactored when paragon supports safari */}
         {/* text inputs for safari */}

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,8 +7,8 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Icon, Hyperlink, Chip } from '@edx/paragon';
-import { CloseSmall } from '@edx/paragon/icons';
+import { Hyperlink, Chip } from '@edx/paragon';
+import { CloseSmall, Add } from '@edx/paragon/icons';
 
 import CollapsibleCourseRuns from './CollapsibleCourseRuns';
 import CourseButtonToolbar from './CourseButtonToolbar';
@@ -114,7 +114,7 @@ export class BaseEditCourseForm extends React.Component {
         className="btn btn-block rounded mt-3 new-run-button"
         disabled={disabled}
       >
-        <Icon className="fa fa-plus" /> Add Course Run
+        <Add /> Add Course Run
       </button>
     );
 
@@ -333,7 +333,7 @@ export class BaseEditCourseForm extends React.Component {
             onToggle={this.setCollapsible}
           >
             <div className="mb-3">
-              <span className="text-info" aria-hidden> All fields are required for publication unless otherwise specified.</span>
+              <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
             </div>
             <Field
               name="title"

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -31,6 +31,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -109,7 +110,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -644,6 +645,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -722,7 +724,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -1257,6 +1259,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -1335,7 +1338,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -1870,6 +1873,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -1948,7 +1952,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -2483,6 +2487,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -2561,7 +2566,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -3108,6 +3113,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
             target="_blank"
           >
             edX101+DemoX
@@ -3186,7 +3192,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>
@@ -3760,6 +3766,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
           Studio URL - 
           <withDeprecatedProps(Hyperlink)
             destination="http://localhost:18010/course/undefined"
+            isInline={true}
             target="_blank"
           />
           <OverlayTrigger
@@ -3835,7 +3842,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
   >
     <span
       aria-hidden={true}
-      className="text-info"
+      className="text-primary-500"
     >
        All fields are required for publication unless otherwise specified.
     </span>

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -1699,9 +1699,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar
@@ -1761,7 +1759,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -3455,9 +3453,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar
@@ -3517,7 +3513,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -5514,9 +5510,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar
@@ -5576,7 +5570,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -7270,9 +7264,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar
@@ -7332,7 +7324,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -8938,9 +8930,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar
@@ -9000,7 +8990,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       >
         <span
           aria-hidden={true}
-          className="text-info"
+          className="text-primary-500"
         >
            All fields are required for publication unless otherwise specified.
         </span>
@@ -10640,9 +10630,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       disabled={true}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-plus"
-      />
+      <SvgAdd />
        Add Course Run
     </button>
     <CourseButtonToolbar

--- a/src/components/FieldHelp/index.jsx
+++ b/src/components/FieldHelp/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { InfoOutline } from '@edx/paragon/icons';
 import jsxToString from 'jsx-to-string';
 import ReactTooltip from 'react-tooltip';
 
@@ -48,12 +49,12 @@ class FieldHelp extends React.Component {
       <span id={this.props.id} className={this.props.className}>
         <button
           type="button"
-          className="btn btn-link py-0 px-1 align-baseline"
+          className={`btn btn-link py-0 px-0 mx-1 align-bottom ${this.props.optional ? 'text-gray-700' : ''}`}
           onClick={this.toggleToolTip}
           onBlur={this.closeToolTip}
           aria-describedby={`${this.props.id}-tooltip`}
         >
-          <span className="fa fa-info-circle" />
+          <InfoOutline />
         </button>
         <span
           className="field-help-data"
@@ -76,12 +77,14 @@ class FieldHelp extends React.Component {
 
 FieldHelp.defaultProps = {
   className: '',
+  optional: false,
 };
 
 FieldHelp.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   tip: PropTypes.node.isRequired,
+  optional: PropTypes.bool,
 };
 
 export default FieldHelp;

--- a/src/components/FieldLabel/index.jsx
+++ b/src/components/FieldLabel/index.jsx
@@ -13,14 +13,14 @@ const FieldLabel = ({
   let requireText = '';
 
   if (optional) {
-    requireText = <span className="text-info" aria-hidden>   Optional</span>;
+    requireText = <span className="text-gray-700" aria-hidden>   (optional)</span>;
   }
 
   return (
     <div id={id} className={className}>
       <strong>{text}</strong>
-      {helpText && id && <FieldHelp id={`${id}-help`} tip={helpText} />}
       {requireText}
+      {helpText && id && <FieldHelp id={`${id}-help`} tip={helpText} optional={optional} />}
       <div><span className="text-muted">{extraText}</span></div>
     </div>
   );

--- a/src/components/RemoveButton/__snapshots__/RemoveButton.test.jsx.snap
+++ b/src/components/RemoveButton/__snapshots__/RemoveButton.test.jsx.snap
@@ -3,13 +3,12 @@
 exports[`RemoveButton renders correctly 1`] = `
 <button
   aria-label="Test Label"
-  className="close float-none"
+  className="close float-none d-flex justify-content-center align-items-center"
   onClick={[Function]}
   title="Test Label"
   type="button"
 >
-  <withDeprecatedProps(Icon)
-    className="fa fa-close"
+  <SvgClose
     id="remove-field"
   />
 </button>

--- a/src/components/RemoveButton/index.jsx
+++ b/src/components/RemoveButton/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { Icon } from '@edx/paragon';
+import { Close } from '@edx/paragon/icons';
 
 const RemoveButton = ({
   className,
@@ -12,14 +12,13 @@ const RemoveButton = ({
 }) => (
   <button
     type="button"
-    className={classNames('close float-none', className)}
+    className={classNames('close float-none d-flex justify-content-center align-items-center', className)}
     aria-label={label}
     title={label}
     onClick={() => onRemove(targetFieldNumber)}
   >
-    <Icon
+    <Close
       id="remove-field"
-      className="fa fa-close"
     />
   </button>
 );

--- a/src/components/SidePanes/Pane.jsx
+++ b/src/components/SidePanes/Pane.jsx
@@ -6,7 +6,7 @@ import { InfoOutline } from '@edx/paragon/icons';
 function Pane(props) {
   return (
     <div className="card mb-3">
-      <div className="card-header bg-primary text-white">
+      <div className="card-header bg-primary-700 text-white">
         {props.title}
         {props.info && (
           <OverlayTrigger

--- a/src/components/SidePanes/User.jsx
+++ b/src/components/SidePanes/User.jsx
@@ -5,16 +5,19 @@ import RemoveButton from '../RemoveButton';
 function User(props) {
   return (
     <div>
-      {props.name}
-      {props.onRemove
-        && (
-        <RemoveButton
-          className="align-text-bottom ml-1"
-          label="Remove"
-          targetFieldNumber={props.userId}
-          onRemove={props.onRemove}
-        />
-        )}
+      <div className="d-flex">
+        <span title={props.name} className="text-gray-800 text-truncate">{props.name}</span>
+        {props.onRemove
+          && (
+          <RemoveButton
+            className="align-text-bottom ml-1"
+            label="Remove"
+            targetFieldNumber={props.userId}
+            onRemove={props.onRemove}
+          />
+          )}
+      </div>
+      <p title={props.email} className="text-gray-500 text-truncate h5 font-weight-normal">{props.email}</p>
     </div>
   );
 }
@@ -25,6 +28,7 @@ User.defaultProps = {
 
 User.propTypes = {
   name: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
   onRemove: PropTypes.func,
   userId: PropTypes.number.isRequired,
 };

--- a/src/components/SidePanes/UsersPane.jsx
+++ b/src/components/SidePanes/UsersPane.jsx
@@ -1,11 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Icon, InputSelect, Alert } from '@edx/paragon';
+import Select, { components } from 'react-select';
+import ReactTooltip from 'react-tooltip';
+
+import { Icon, Alert } from '@edx/paragon';
+import { Add } from '@edx/paragon/icons';
 
 import Pane from './Pane';
 import User from './User';
-import FieldLabel from '../FieldLabel';
+
+// customize react-select dropdown options to show tooltips
+const Option = (props) => (
+  <div className={`tooltip-${props.data.value}`} data-tip data-for={`tooltip-${props.data.value}`}>
+    <components.Option {...props} className={`option-${props.data.value}`} />
+    <ReactTooltip id={`tooltip-${props.data.value}`}>
+      <span>{props.data.label}</span>
+    </ReactTooltip>
+  </div>
+);
 
 class UsersPane extends React.Component {
   displayName(user) {
@@ -21,6 +34,7 @@ class UsersPane extends React.Component {
       addingUser: false,
       newEditorChoice: 0,
     };
+    this.selectRef = React.createRef();
 
     this.addUser = this.addUser.bind(this);
     this.resetEditorChoice = this.resetEditorChoice.bind(this);
@@ -48,8 +62,10 @@ class UsersPane extends React.Component {
   }
 
   addUser() {
-    this.props.addCourseEditor(this.state.newEditorChoice);
-    this.resetEditorChoice();
+    if (this.selectRef.current.state.value) {
+      this.props.addCourseEditor(this.state.newEditorChoice);
+      this.resetEditorChoice();
+    }
   }
 
   resetEditorChoice() {
@@ -75,9 +91,9 @@ class UsersPane extends React.Component {
     return organizationUsers.data.filter(user => !editorIds.has(user.id));
   }
 
-  editorChoiceChanged(value) {
+  editorChoiceChanged(e) {
     this.setState({
-      newEditorChoice: value,
+      newEditorChoice: e.value,
     });
   }
 
@@ -108,12 +124,13 @@ class UsersPane extends React.Component {
         {showPCs
           && (
           <div className="mb-2">
-            <div className="font-weight-bold">Project Coordinators</div>
+            <div className="font-weight-bold text-dark-700 mb-2">Project coordinators</div>
             {organizationRoles.data.map(role => (
               <User
                 key={role.id}
                 userId={role.id}
-                name={this.displayName(role.user)}
+                name={role.user.full_name}
+                email={role.user.email}
               />
             ))}
           </div>
@@ -123,12 +140,13 @@ class UsersPane extends React.Component {
         {showEditors
           && (
           <div>
-            <div className="font-weight-bold">Course Editors</div>
+            <div className="font-weight-bold text-dark-700 mb-2">Course editors</div>
             {courseEditors.data.map(editor => (
               <User
                 key={editor.id}
                 userId={editor.id}
-                name={this.displayName(editor.user)}
+                name={editor.user.full_name}
+                email={editor.user.email}
                 onRemove={removeCourseEditor}
               />
             ))}
@@ -136,24 +154,48 @@ class UsersPane extends React.Component {
               || <div>All team members</div>}
             {showAddButton
               && (
-              <button type="button" className="btn btn-link p-0 usersPane-startAdd" onClick={this.startAddingUser}>
-                <Icon className="fa fa-plus" /> {hasEditor ? 'Add editor' : 'Set editor'}
+              <button type="button" className="btn btn-link text-dark-900 p-0 usersPane-startAdd" onClick={this.startAddingUser}>
+                <Add /> {hasEditor ? 'Add editor' : 'Set editor'}
               </button>
               )}
             {addingUser
               && (
               <div className="mt-2">
                 <hr />
-                <InputSelect
+                <div className="font-weight-bold text-dark-700 mb-2">Select an editor:</div>
+                <Select
                   name="add_editor"
-                  label={(
-                    <FieldLabel
-                      id="add_editor.label"
-                      text="Select an editor:"
-                    />
-                  )}
+                  placeholder="Search..."
+                  ref={this.selectRef}
+                  components={{
+                    IndicatorSeparator: () => null,
+                    Option,
+                  }}
+                  styles={{
+                    control: base => ({
+                      ...base,
+                      marginBottom: 16,
+                      cursor: 'text',
+
+                    }),
+                    option: base => ({
+                      ...base,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+
+                    }),
+                    singleValue: (base, state) => ({
+                      ...base,
+                      color: state.selectProps.menuIsOpen ? '#D3D3D3' : base.color,
+                    }),
+
+                  }}
                   options={
-                    editorChoices.map(user => ({ label: this.displayName(user), value: user.id }))
+                    editorChoices.map(user => ({
+                      label: this.displayName(user),
+                      value: user.id,
+                    }))
                   }
                   onChange={this.editorChoiceChanged}
                 />
@@ -179,6 +221,18 @@ class UsersPane extends React.Component {
     );
   }
 }
+
+Option.defaultProps = {
+  className: '',
+};
+
+Option.propTypes = {
+  data: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.number.isRequired,
+  }).isRequired,
+  className: PropTypes.string,
+};
 
 UsersPane.defaultProps = {
   addCourseEditor: null,

--- a/src/components/SidePanes/UsersPane.test.jsx
+++ b/src/components/SidePanes/UsersPane.test.jsx
@@ -87,9 +87,11 @@ describe('UsersPane', () => {
     />);
     const users = wrapper.find(User);
     expect(users).toHaveLength(3);
-    expect(users.at(0).prop('name')).toEqual('Editor 1 (one@example.com)');
+    expect(users.at(0).prop('name')).toEqual('Editor 1');
+    expect(users.at(0).prop('email')).toEqual('one@example.com');
     expect(users.at(1).prop('name')).toEqual('No Email');
-    expect(users.at(2).prop('name')).toEqual('Editor 3 (three@example.com)');
+    expect(users.at(2).prop('name')).toEqual('Editor 3');
+    expect(users.at(2).prop('email')).toEqual('three@example.com');
   });
 
   it('has label for no editors', () => {
@@ -125,8 +127,10 @@ describe('UsersPane', () => {
     const startAddButton = wrapper.find('.usersPane-startAdd');
     startAddButton.simulate('click');
 
-    const selectOption = wrapper.find('option');
-    expect(selectOption.html()).toEqual('<option value="14">New User (new@example.com)</option>');
+    wrapper.instance().selectRef.current.onMenuOpen();
+    wrapper.update();
+    const selectOption = wrapper.find('.option-14').hostNodes(); // 14 is new editor's user id
+    selectOption.simulate('click');
 
     const addButton = wrapper.find('.usersPane-add');
     addButton.simulate('click');
@@ -140,6 +144,7 @@ describe('UsersPane', () => {
     />);
     const users = wrapper.find(User);
     expect(users).toHaveLength(1);
-    expect(users.at(0).prop('name')).toEqual('PC 1 (pc@example.com)');
+    expect(users.at(0).prop('name')).toEqual('PC 1');
+    expect(users.at(0).prop('email')).toEqual('pc@example.com');
   });
 });

--- a/src/components/Staffer/__snapshots__/Staffer.test.jsx.snap
+++ b/src/components/Staffer/__snapshots__/Staffer.test.jsx.snap
@@ -20,8 +20,8 @@ exports[`Staffer renders the staffer 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-trash fa-fw text-danger"
+      <SvgDelete
+        className="text-gray-500"
         id="delete-icon-2aba6189-ad7e-45a8-b269-bea071b80391"
         screenReaderText="Remove Dave Grohl"
       />
@@ -31,8 +31,8 @@ exports[`Staffer renders the staffer 1`] = `
       onClick={[Function]}
       to="/instructors/2aba6189-ad7e-45a8-b269-bea071b80391"
     >
-      <withDeprecatedProps(Icon)
-        className="fa fa-edit fa-fw"
+      <SvgEdit
+        className="text-gray-500"
         id="edit-icon-2aba6189-ad7e-45a8-b269-bea071b80391"
         screenReaderText="Edit Dave Grohl"
         title="Edit"

--- a/src/components/Staffer/index.jsx
+++ b/src/components/Staffer/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '@edx/paragon';
 import { Link } from 'react-router-dom';
+
+import { Edit, Delete } from '@edx/paragon/icons';
 
 import sourceInfo from '../../data/actions/sourceInfo';
 import store from '../../data/store';
@@ -26,9 +27,9 @@ export const Staffer = ({
         onClick={() => onRemove(item.uuid)}
         disabled={disabled}
       >
-        <Icon
+        <Delete
           id={`delete-icon-${item.uuid}`}
-          className="fa fa-trash fa-fw text-danger"
+          className="text-gray-500"
           screenReaderText={`Remove ${getStafferName(item)}`}
         />
       </button>
@@ -40,9 +41,9 @@ export const Staffer = ({
           className="btn mr-1 p-0"
           onClick={() => store.dispatch(sourceInfo(referrer, courseRunKey))}
         >
-          <Icon
+          <Edit
             id={`edit-icon-${item.uuid}`}
-            className="fa fa-edit fa-fw"
+            className="text-gray-500"
             screenReaderText={`Edit ${getStafferName(item)}`}
             title="Edit"
           />

--- a/src/containers/MainApp/AppTests.test.jsx
+++ b/src/containers/MainApp/AppTests.test.jsx
@@ -82,7 +82,7 @@ describe('App', () => {
     const screen = renderAppWithState(['/']);
 
     // New Course Button should be present
-    expect(screen.find('div.btn-group a button').text()).toEqual('New Course');
+    expect(screen.find('div.btn-group a button').text()).toEqual('New course');
 
     // Table Should be present at main route with data
     expect(screen.find(TableComponent)).toHaveLength(1);


### PR DESCRIPTION
# [PROD-2733](https://2u-internal.atlassian.net/browse/PROD-2733)

## Description

In this PR, we make some small UI changes in publisher. In particular, the changes introduced are as follows:-

- Fix logo link to redirect to publisher home page
- Use sentence case for course table headings and New Course button
- Shift new course button towards the right of the page
- Remove lock icon for in-review courses
- Change font-color at a few places
- Updating a few icons to those from @edx/paragon
- Update Form Labels for Optional fields

## Testing Instructions

1. On the publisher landing page : -

      - Verify that the New Course Button and Table Headings are in sentence case
      - Verify that the New Course Button occurs on the far right of the page
      - Verify that in the Courses Table, in-review courses no longer have a lock icon displayed in the States column
      - Verify that clicking on the logo on the top-left redirects to the same page

2.  On a course details page ("/courses/{uuid}/") : -

      - Verify that in the Users Pane, Add Editor and Remove Editor icons have been updated
      - Verify that Staff Add and Delete Icons have been updated
      - Verify that Labels for Optional Fields have been updated




## ScreenShots
The changes are too small to visually stand out. It may seem like solving a 'Find the Differences' puzzle whilst comparing the before and after pictures below

### Before

<img width="1680" alt="Screenshot 2022-12-13 at 11 52 58 AM" src="https://user-images.githubusercontent.com/87228907/208009105-bbf62232-ae82-49cc-9383-b4f2af8e1b24.png">
<img width="1680" alt="Screenshot 2022-12-13 at 12 33 29 PM" src="https://user-images.githubusercontent.com/87228907/208009127-10906b66-fe89-4fcd-879d-66e9c50ccfdb.png">
<img width="1096" alt="Screenshot 2022-12-13 at 12 33 57 PM" src="https://user-images.githubusercontent.com/87228907/208009150-bea3b970-828f-4962-b668-a5de4f9c4883.png">

### After
<img width="1680" alt="Screenshot 2022-12-13 at 12 36 05 PM" src="https://user-images.githubusercontent.com/87228907/208009198-f041281c-b5b8-4364-89c3-21f773a3627e.png">
<img width="1680" alt="Screenshot 2022-12-13 at 12 37 49 PM" src="https://user-images.githubusercontent.com/87228907/208009206-66b74965-fad5-4ce3-a97d-0b89b513b039.png">
<img width="1110" alt="Screenshot 2022-12-13 at 12 38 21 PM" src="https://user-images.githubusercontent.com/87228907/208009208-2276e785-03ac-445d-b02c-624f3b8eb7c3.png">

## Discussion

The ticket asks for course table filtering to be implemented using edx Paragon Data Table component. However the Paragon component appears to implement filtering on the frontend whereas our current implementation is backend based. Converting our current filtering implementation to a frontend-based one involves non-trivial design decisions. Hence we have chosen to ignore this part for now.

## ToDo

- Update test snapshots

