### PR TITLE
fix: increase the character limit for instructor bio

### DIFF
--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -102,7 +102,7 @@ const BaseStafferForm = ({
           name="bio"
           component={RichEditor}
           label={<FieldLabel text="Biography" />}
-          maxChars={250}
+          maxChars={1000}
           validate={basicValidate}
           id="bio"
         />

--- a/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
@@ -145,7 +145,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
           text="Biography"
         />
       }
-      maxChars={250}
+      maxChars={1000}
       name="bio"
       validate={[Function]}
     />
@@ -363,7 +363,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
           text="Biography"
         />
       }
-      maxChars={250}
+      maxChars={1000}
       name="bio"
       validate={[Function]}
     />
@@ -581,7 +581,7 @@ exports[`StafferForm renders html correctly 1`] = `
           text="Biography"
         />
       }
-      maxChars={250}
+      maxChars={1000}
       name="bio"
       validate={[Function]}
     />
@@ -799,7 +799,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
           text="Biography"
         />
       }
-      maxChars={250}
+      maxChars={1000}
       name="bio"
       validate={[Function]}
     />
@@ -1017,7 +1017,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
           text="Biography"
         />
       }
-      maxChars={250}
+      maxChars={1000}
       name="bio"
       validate={[Function]}
     />


### PR DESCRIPTION
[PROD-3052](https://2u-internal.atlassian.net/browse/PROD-3052)
This PR increases the character limit for the course instructor's bio to 1000 characters.
As there is no limit on the backend for the bio field nor in the serializer, this change is only related to the front end.
<img width="377" alt="image" src="https://user-images.githubusercontent.com/78806673/207799246-4f6993e4-1e48-46a0-a92c-0c2f27141444.png">
Testing instructions:
- Create a people object from the discovery admin.
- Run the frontend-app-publisher locally.
- Visit the localhost:18400/instructors/{people.uuid} page.
  > uuid is the uuid of the people object created in the first step.
- Verify that the bio field has a character limit of 1000.
Screenshot:
![image](https://user-images.githubusercontent.com/78806673/207800410-808dfd91-8450-4bf4-80e6-8ec80e9051db.png)