### PR TITLE
feat: add searchable dropdown for course tags

### DIFF
--- a/src/components/CourseTags/fetchCourseTagSuggestions.jsx
+++ b/src/components/CourseTags/fetchCourseTagSuggestions.jsx
@@ -1,7 +1,0 @@
-const contains = (stringA, stringB) => stringA.toLowerCase().includes(stringB.toLowerCase());
-const filterSuggestions = (value, allCourseTags) => allCourseTags.filter(({ name }) => contains(name, value));
-
-export default (allValues) => {
-  const inner = (value) => Promise.resolve({ data: filterSuggestions(value, allValues) });
-  return inner;
-};

--- a/src/components/CourseTags/renderCourseTagSuggestion.jsx
+++ b/src/components/CourseTags/renderCourseTagSuggestion.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default (suggestion) => (
-  <div className="d-flex flex-row m-1 p-1">
-    <div className="m-1 p-1 w-75">
-      <div className="m-1 p-1">{suggestion.value}</div>
-    </div>
-  </div>
-);

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,8 +7,10 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Hyperlink, Chip } from '@edx/paragon';
-import { CloseSmall, Add } from '@edx/paragon/icons';
+import { Hyperlink } from '@edx/paragon';
+import { Add } from '@edx/paragon/icons';
+
+import ReduxFormCreatableSelect from '../ReduxFormCreatableSelect';
 
 import CollapsibleCourseRuns from './CollapsibleCourseRuns';
 import CourseButtonToolbar from './CourseButtonToolbar';
@@ -27,7 +29,7 @@ import PriceList from '../PriceList';
 
 import { PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG } from '../../data/constants';
 import { titleHelp, typeHelp, urlSlugHelp } from '../../helpText';
-import { handleCourseEditFail, editCourseValidate } from '../../utils/validation';
+import { handleCourseEditFail, editCourseValidate, courseTagValidate } from '../../utils/validation';
 import {
   formatCollaboratorOptions,
   getOptionsData, isPristine, parseCourseTypeOptions, parseOptions,
@@ -38,8 +40,6 @@ import ListField from '../ListField';
 import { Collaborator } from '../Collaborator';
 import renderSuggestion from '../Collaborator/renderSuggestion';
 import fetchCollabSuggestions from '../Collaborator/fetchCollabSuggestions';
-import fetchCourseTagSuggestions from '../CourseTags/fetchCourseTagSuggestions';
-import renderCourseTagSuggestion from '../CourseTags/renderCourseTagSuggestion';
 import AdditionalMetadataFields from './AdditionalMetadataFields';
 
 export class BaseEditCourseForm extends React.Component {
@@ -57,7 +57,6 @@ export class BaseEditCourseForm extends React.Component {
     this.toggleCourseRun = this.toggleCourseRun.bind(this);
     this.collapseAllCourseRuns = this.collapseAllCourseRuns.bind(this);
     this.setCourseRunCollapsibles = this.setCourseRunCollapsibles.bind(this);
-    this.handleCourseTagChange = this.handleCourseTagChange.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -177,35 +176,60 @@ export class BaseEditCourseForm extends React.Component {
     );
   }
 
-  formatCourseTags(topics, setCourseTags) {
-    return (
-      topics
-      && topics.length
-      && topics.map((topic) => (
-        <Chip
-          variant="dark"
-          iconAfter={CloseSmall}
-          onClick={() => {
-            setCourseTags([...topics.filter((item) => item !== topic)]);
-          }}
-        >
-          {topic}
-        </Chip>
-      ))
-    );
+  courseTagObjectsToSelectOptions(allCourseTags) {
+  /*  transform an array of course tag objects e.g
+        [
+          {
+            name: 'mba',
+            value: 'mba'
+          },
+
+          {
+            name: 'mba-gmat',
+            value: 'mba-gmat'
+          }
+        ]
+
+      to a format expected by ReduxFormCreatableSelect i.e
+        [
+          {
+            label: 'mba',
+            value: 'mba'
+          },
+
+          {
+            label: 'mba-gmat',
+            value: 'mba-gmat'
+          }
+        ]
+  */
+
+    return allCourseTags.map(tag => ({
+      label: tag.value,
+      value: tag.value,
+    }));
   }
 
-  handleCourseTagChange(value, courseTags, setCourseTags) {
-    if (value && value.includes(',') && value.slice(-1) === ',') {
-      const tag = value
-        .split(',')
-        .filter((item) => item !== '')
-        .map((item) => item.toLowerCase().trim());
-      this.setState({ courseTag: '' });
-      setCourseTags([...new Set([...courseTags, ...tag])]);
-    } else {
-      this.setState({ courseTag: value });
-    }
+  courseTagsToSelectValues(tags) {
+  /*  transform an array of course tags e.g `['mba', 'mba-gmat']` to
+      a format expected by ReduxFormCreatableSelect i.e
+        [
+          {
+            label: 'mba',
+            value: 'mba'
+          },
+
+          {
+            label: 'mba-gmat',
+            value: 'mba-gmat'
+          }
+        ]
+  */
+
+    return tags.map(tag => ({
+      label: tag,
+      value: tag,
+    }));
   }
 
   toggleCourseRun(index, value) {
@@ -469,11 +493,7 @@ export class BaseEditCourseForm extends React.Component {
             />
             <Field
               name="tags"
-              itemType="topic"
-              component={RenderInputTextField}
-              fetchSuggestions={fetchCourseTagSuggestions(allCourseTags)}
-              renderSuggestion={renderCourseTagSuggestion}
-              type="text"
+              component={ReduxFormCreatableSelect}
               label={(
                 <>
                   <FieldLabel
@@ -481,19 +501,28 @@ export class BaseEditCourseForm extends React.Component {
                     text="Topics"
                     helpText={(
                       <p>
-                        You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                        You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                       </p>
                     )}
                     optional
                   />
-                  {courseTags
-                    && courseTags.length ? this.formatCourseTags(courseTags, setCourseTags) : null}
                 </>
               )}
               disabled={disabled || !administrator}
               value={this.state.courseTag}
-              onChange={(e) => this.handleCourseTagChange(e, courseTags, setCourseTags)}
               optional
+              currentValue={
+                Array.isArray(courseTags)
+                  ? this.courseTagsToSelectValues(courseTags)
+                  : null
+              }
+              setValue={(newValue) => setCourseTags(newValue)}
+              defaultOptions={
+                Array.isArray(allCourseTags)
+                  ? this.courseTagObjectsToSelectOptions(allCourseTags)
+                  : []
+              }
+              createOptionValidator={courseTagValidate}
             />
             {showMarketingFields && (
               <>

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -324,9 +324,10 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -334,7 +335,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -344,10 +345,8 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />
@@ -2040,9 +2039,10 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -2050,7 +2050,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -2060,10 +2060,8 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />
@@ -3794,9 +3792,10 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -3804,7 +3803,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -3814,10 +3813,8 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />
@@ -5851,9 +5848,10 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -5861,7 +5859,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -5871,10 +5869,8 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />
@@ -7601,9 +7597,10 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -7611,7 +7608,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -7621,10 +7618,8 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />
@@ -9267,9 +9262,10 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       />
       <Field
         component={[Function]}
+        createOptionValidator={[Function]}
+        currentValue={Array []}
+        defaultOptions={Array []}
         disabled={true}
-        fetchSuggestions={[Function]}
-        itemType="topic"
         label={
           <React.Fragment>
             <FieldLabel
@@ -9277,7 +9273,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
               extraText=""
               helpText={
                 <p>
-                  You can add comma separated tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
+                  You can add tags in the format mba-no-gmat,mba,mba_4_modules,mba_NY
                 </p>
               }
               id="tags.label"
@@ -9287,10 +9283,8 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
           </React.Fragment>
         }
         name="tags"
-        onChange={[Function]}
         optional={true}
-        renderSuggestion={[Function]}
-        type="text"
+        setValue={[Function]}
         value=""
       />
       <hr />

--- a/src/components/ReduxFormCreatableSelect/index.jsx
+++ b/src/components/ReduxFormCreatableSelect/index.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AsyncCreatableSelect from 'react-select/async-creatable';
+
+import DiscoveryDataApiService from '../../data/services/DiscoveryDataApiService';
+
+const ReduxFormCreatableSelect = props => {
+  const {
+    input, defaultOptions, currentValue, setValue,
+  } = props;
+
+  const loadOptions = (inputValue, callback) => DiscoveryDataApiService.fetchCourseTags(inputValue)
+    .then((response) => {
+      callback(response.data.map(tag => (
+        {
+          label: tag.value,
+          value: tag.value,
+        }
+      )));
+    })
+    .catch(() => {
+      callback(null);
+    });
+
+  return (
+
+    <>
+      {props.label}
+      <AsyncCreatableSelect
+        isMulti
+        onChange={value => {
+          input.onChange(value);
+          setValue(value ? value.map(v => v.label) : []);
+        }}
+        onBlur={() => input.onBlur(input.value)}
+        defaultOptions={defaultOptions}
+        isValidNewOption={props.createOptionValidator}
+        cacheOptions
+        isSearchable
+        styles={{
+          menu: styles => ({ ...styles, zIndex: 5 }),
+          control: styles => ({ ...styles, marginTop: '8px' }),
+        }}
+        value={currentValue}
+        loadOptions={loadOptions}
+        isDisabled={props.disabled}
+      />
+    </>
+  );
+};
+
+ReduxFormCreatableSelect.defaultProps = {
+  disabled: false,
+};
+
+ReduxFormCreatableSelect.propTypes = {
+  input: PropTypes.shape({
+    onBlur: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  }).isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  defaultOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  }).isRequired).isRequired,
+  currentValue: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  }).isRequired).isRequired,
+  setValue: PropTypes.func.isRequired,
+  createOptionValidator: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+export default ReduxFormCreatableSelect;

--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -198,9 +198,13 @@ class DiscoveryDataApiService {
     return getAuthenticatedHttpClient().get(url);
   }
 
-  static fetchCourseTags() {
+  static fetchCourseTags(q = '', limit = 20) {
     const url = `${process.env.DISCOVERY_API_BASE_URL}/taggit_autosuggest/list/taggit.tag/`;
-    return getAuthenticatedHttpClient().get(url);
+    const queryParams = {
+      limit,
+      q,
+    };
+    return getAuthenticatedHttpClient().get(url, { params: queryParams });
   }
 
   static editCourse(courseData) {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -8,6 +8,13 @@ const requiredMessage = 'This field is required';
 // Basic validation that ensures some value was entered
 const basicValidate = value => (value ? undefined : requiredMessage);
 
+function courseTagValidate(tagValue, selectValue, options) {
+  // tagValue should only contain alphabets, numbers, hyphen and underscore
+  if (!/^[a-zA-Z0-9_-]+$/.test(tagValue)) { return false; }
+  // disallow tags that have already been selected or are present in options(dropdown)
+  return ![...selectValue, ...options].some(x => x.label.toLowerCase() === tagValue.toLowerCase());
+}
+
 /**
  * Iterates through errors on a form and returns the first field name with an error.
  *
@@ -145,4 +152,5 @@ export {
   getFieldName,
   handleCourseEditFail,
   editCourseValidate,
+  courseTagValidate,
 };


### PR DESCRIPTION
# [PROD-2952](https://2u-internal.atlassian.net/browse/PROD-2952)

## Description

This PR adds a searchable dropdown for course tags field. The tags are fetched async from the backend based on user input. 

## Testing

1. Go to a course page and navigate to the **Topics** section in Course Details.
2. Add topics of your choice or select from the available ones.
3. You can click on any chip to remove the tag from the course.
4. Don't forget to Save the course at the end.

## UI Sample

https://user-images.githubusercontent.com/87228907/210012888-2658d9d5-878f-43e4-b6a5-f8cc50f5581e.mov

