### PR TITLE
fix: make organization field editable in instructor form

### DIFF
--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -95,7 +95,7 @@ const BaseStafferForm = ({
           component={RenderInputTextField}
           type="text"
           label={<FieldLabel text="Organization" />}
-          extraInput={{ value: organizationName }}
+          extraInput={{ defaultValue: organizationName }}
           required
         />
         <Field

--- a/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
@@ -115,7 +115,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
       component={[Function]}
       extraInput={
         Object {
-          "value": "",
+          "defaultValue": "",
         }
       }
       label={
@@ -333,7 +333,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
       component={[Function]}
       extraInput={
         Object {
-          "value": "",
+          "defaultValue": "",
         }
       }
       label={
@@ -551,7 +551,7 @@ exports[`StafferForm renders html correctly 1`] = `
       component={[Function]}
       extraInput={
         Object {
-          "value": "",
+          "defaultValue": "",
         }
       }
       label={
@@ -769,7 +769,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
       component={[Function]}
       extraInput={
         Object {
-          "value": "",
+          "defaultValue": "",
         }
       }
       label={
@@ -987,7 +987,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
       component={[Function]}
       extraInput={
         Object {
-          "value": "",
+          "defaultValue": "",
         }
       }
       label={


### PR DESCRIPTION
# [PROD-2734](https://2u-internal.atlassian.net/browse/PROD-2734)

## Description

This PR makes the organization field editable in instructor forms

## Testing Instructions

1. Go to `/instructors/new`. Try creating an instructor of your choice.
2. Type in an organization field of your choice
3. Hit `Create`
4. Verify that the instructor has indeed been created in discovery admin.

