### PR TITLE
fix: update DateTime field to update custom time

### DIFF
--- a/src/components/DateTimeField/index.jsx
+++ b/src/components/DateTimeField/index.jsx
@@ -125,7 +125,7 @@ class DateTimeField extends React.Component {
               placeholder="HH:mm"
               required={required}
               disabled={disabled}
-              onChange={event => this.updateDate(event.target.value)}
+              onChange={event => this.updateTime(event.target.value)}
             />
           </Form.Group>
         </div>


### PR DESCRIPTION
[PROD-3095](https://2u-internal.atlassian.net/browse/PROD-3095)

## Description
This PR updates the `DateTimeField` component to store the time. Previously, the time-named field was using the `updateDate` method on the `onChange` event to change the state of time but because of an invalid date format, the time was not stored. This PR fixes that issue.

Testing Instructions:
- Run the frontend-app-publisher locally
- Visit the localhost:18400/courses/{course.uuid} page.
(You can do this on any of the existing courses)
- Navigate to the course run form of the course
- Verify you can update `Upgrade deadline override time (UTC)` on onChange event

#### Before
> Error
<img width="434" alt="image" src="https://user-images.githubusercontent.com/78806673/212696690-f5d65479-e038-4680-931d-88995fafce5d.png">

https://user-images.githubusercontent.com/78806673/212697202-dc50288a-23fa-42a2-b359-4b07b276c290.mov





#### After

https://user-images.githubusercontent.com/78806673/212696928-1049e891-9a83-4625-8d12-1ba52cdd952e.mov




