### PR TITLE
feat: add Geolocation fields on course edit page

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -41,6 +41,7 @@ import { Collaborator } from '../Collaborator';
 import renderSuggestion from '../Collaborator/renderSuggestion';
 import fetchCollabSuggestions from '../Collaborator/fetchCollabSuggestions';
 import AdditionalMetadataFields from './AdditionalMetadataFields';
+import GeoLocationFields from './GeoLocationFields';
 
 export class BaseEditCourseForm extends React.Component {
   constructor(props) {
@@ -1204,6 +1205,8 @@ export class BaseEditCourseForm extends React.Component {
                 />
               </>
             )}
+
+            {administrator && (<GeoLocationFields disabled={disabled} />)}
           </Collapsible>
           {open && courseType && courseType === EXECUTIVE_EDUCATION_SLUG && (
             <AdditionalMetadataFields disabled={disabled} />

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -388,6 +388,9 @@ describe('EditCoursePage', () => {
       title: 'demo4004',
       topics: [],
       type: '8a8f30e1-23ce-4ed3-a361-1325c656b67b',
+      geoLocationName: null,
+      geoLocationLat: null,
+      geoLocationLng: null,
       url_slug: 'demo4004',
       videoSrc: null,
       editable: true,
@@ -406,6 +409,11 @@ describe('EditCoursePage', () => {
         restriction_type: 'allowlist',
         countries: ['AF', 'AX'],
         states: ['AL'],
+      },
+      geolocation: {
+        lat: null,
+        lng: null,
+        location_name: null,
       },
       organization_logo_override: 'http://image.src.small',
       organization_short_code_override: 'test short code',
@@ -956,6 +964,11 @@ describe('EditCoursePage', () => {
       url_slug: 'demo4004',
       uuid: '00000000-0000-0000-0000-000000000000',
       video: { src: null },
+      geolocation: {
+        lat: null,
+        lng: null,
+        location_name: null,
+      },
     };
 
     it('handleCourseSubmit properly for executive education courses, will add additional metadata fields', () => {

--- a/src/components/EditCoursePage/GeoLocationFields.jsx
+++ b/src/components/EditCoursePage/GeoLocationFields.jsx
@@ -27,6 +27,9 @@ const GeoLocationFields = (props) => {
         <Field
           name="geolocation.location_name"
           component={RenderInputTextField}
+          props={{
+            name: 'geolocation.location_name',
+          }}
           label={(
             <FieldLabel
               id="geolocation.location_name.label"
@@ -45,9 +48,12 @@ const GeoLocationFields = (props) => {
         />
 
         <Field
-          name="geolocation.lng"
-          type="number"
           component={RenderInputTextField}
+          name="geolocation.lng"
+          props={{
+            name: 'geolocation.lng',
+          }}
+          type="number"
           label={(
             <FieldLabel
               id="geolocation.longitude.label"
@@ -70,9 +76,12 @@ const GeoLocationFields = (props) => {
         />
 
         <Field
-          name="geolocation.lat"
-          type="number"
           component={RenderInputTextField}
+          name="geolocation.lat"
+          props={{
+            name: 'geolocation.lat',
+          }}
+          type="number"
           label={(
             <FieldLabel
               id="geolocation.latitude.label"

--- a/src/components/EditCoursePage/GeoLocationFields.jsx
+++ b/src/components/EditCoursePage/GeoLocationFields.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import PropTypes from 'prop-types';
+import RenderInputTextField from '../RenderInputTextField';
+import FieldLabel from '../FieldLabel';
+
+const GeoLocationFields = (props) => {
+  const {
+    disabled,
+  } = props;
+
+  return (
+    <div className="collapsible-card pgn_collapsible mt-4">
+      <div className="collapsible-body">
+        <FieldLabel
+          text="Merchandising Geolocation Data"
+          className="h3 font-weight-normal mb-3"
+          id="geolocation.info"
+          helpText={(
+            <div>
+              <p>
+                Location name, longitude, and latitude must be provided together for successful data update.
+              </p>
+            </div>
+            )}
+        />
+        <Field
+          name="geolocation.location_name"
+          component={RenderInputTextField}
+          label={(
+            <FieldLabel
+              id="geolocation.location_name.label"
+              text="Location Name"
+              helpText={(
+                <div>
+                  <p>
+                    The name of the location present on the given longitude and latitude.
+                  </p>
+                </div>
+                )}
+            />
+                )}
+          disabled={disabled}
+          required={false}
+        />
+
+        <Field
+          name="geolocation.lng"
+          type="number"
+          component={RenderInputTextField}
+          label={(
+            <FieldLabel
+              id="geolocation.longitude.label"
+              text="Longitude"
+              helpText={(
+                <div>
+                  <p>
+                    Longitude of the location from where the course is being offered.
+                  </p>
+                </div>
+                )}
+            />
+                )}
+          extraInput={{
+            min: -180,
+            max: 180,
+          }}
+          disabled={disabled}
+          required={false}
+        />
+
+        <Field
+          name="geolocation.lat"
+          type="number"
+          component={RenderInputTextField}
+          label={(
+            <FieldLabel
+              id="geolocation.latitude.label"
+              text="Latitude"
+              helpText={(
+                <div>
+                  <p>
+                    Latitude of the location from where the course is being offered.
+                  </p>
+                </div>
+                )}
+            />
+                )}
+          extraInput={{
+            min: -90,
+            max: 90,
+          }}
+          disabled={disabled}
+          required={false}
+        />
+
+      </div>
+    </div>
+  );
+};
+
+GeoLocationFields.propTypes = {
+  disabled: PropTypes.bool,
+};
+
+GeoLocationFields.defaultProps = {
+  disabled: false,
+};
+
+export default GeoLocationFields;

--- a/src/components/EditCoursePage/GeoLocationFields.jsx
+++ b/src/components/EditCoursePage/GeoLocationFields.jsx
@@ -25,14 +25,15 @@ const GeoLocationFields = (props) => {
             )}
         />
         <Field
-          name="geolocation.location_name"
+          name="geoLocationName"
           component={RenderInputTextField}
+          type="text"
           props={{
-            name: 'geolocation.location_name',
+            name: 'geoLocationName',
           }}
           label={(
             <FieldLabel
-              id="geolocation.location_name.label"
+              id="geoLocationName.label"
               text="Location Name"
               helpText={(
                 <div>
@@ -44,19 +45,19 @@ const GeoLocationFields = (props) => {
             />
                 )}
           disabled={disabled}
-          required={false}
+          optional
         />
 
         <Field
           component={RenderInputTextField}
-          name="geolocation.lng"
+          name="geoLocationLng"
           props={{
-            name: 'geolocation.lng',
+            name: 'geoLocationLng',
           }}
-          type="number"
+          type="text"
           label={(
             <FieldLabel
-              id="geolocation.longitude.label"
+              id="geoLocationLng.label"
               text="Longitude"
               helpText={(
                 <div>
@@ -72,19 +73,19 @@ const GeoLocationFields = (props) => {
             max: 180,
           }}
           disabled={disabled}
-          required={false}
+          optional
         />
 
         <Field
           component={RenderInputTextField}
-          name="geolocation.lat"
+          name="geoLocationLat"
           props={{
-            name: 'geolocation.lat',
+            name: 'geoLocationLat',
           }}
-          type="number"
+          type="text"
           label={(
             <FieldLabel
-              id="geolocation.latitude.label"
+              id="geoLocationLat.label"
               text="Latitude"
               helpText={(
                 <div>
@@ -100,7 +101,7 @@ const GeoLocationFields = (props) => {
             max: 90,
           }}
           disabled={disabled}
-          required={false}
+          optional
         />
 
       </div>

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -4784,6 +4784,9 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
         optional={true}
         type="number"
       />
+      <GeoLocationFields
+        disabled={true}
+      />
     </CustomCollapsible>
     <FieldLabel
       className="mt-4 mb-2 h2"

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -134,11 +134,9 @@ exports[`EditCoursePage renders html correctly 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -641,11 +639,9 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -1480,11 +1476,9 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -1684,11 +1678,9 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -2605,11 +2597,9 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -2825,11 +2815,9 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3388,11 +3376,9 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3585,11 +3571,9 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3867,11 +3851,9 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -4064,11 +4046,9 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
-          "geolocation": Object {
-            "lat": null,
-            "lng": null,
-            "location_name": null,
-          },
+          "geoLocationLat": null,
+          "geoLocationLng": null,
+          "geoLocationName": null,
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -134,6 +134,11 @@ exports[`EditCoursePage renders html correctly 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -636,6 +641,11 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -1470,6 +1480,11 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -1669,6 +1684,11 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -2585,6 +2605,11 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "enterprise_subscription_inclusion": undefined,
           "faq": "",
           "full_description": "<p>long desc</p>",
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": "http://path/to/image/woo.small",
           "in_year_value": Object {
             "per_click_international": null,
@@ -2800,6 +2825,11 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3358,6 +3388,11 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3550,6 +3585,11 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -3827,6 +3867,11 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,
@@ -4019,6 +4064,11 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
           "enterprise_subscription_inclusion": undefined,
           "faq": undefined,
           "full_description": undefined,
+          "geolocation": Object {
+            "lat": null,
+            "lng": null,
+            "location_name": null,
+          },
           "imageSrc": undefined,
           "in_year_value": Object {
             "per_click_international": null,

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -315,15 +315,15 @@ class EditCoursePage extends React.Component {
   formatGeoLocationFields(courseData) {
     if (courseData?.geolocation) {
       return {
-        location_name: courseData.geolocation.location_name,
-        lng: courseData.geolocation.lng,
-        lat: courseData.geolocation.lat,
+        geoLocationName: courseData.geolocation.location_name,
+        geoLocationLng: courseData.geolocation.lng,
+        geoLocationLat: courseData.geolocation.lat,
       };
     }
     return {
-      location_name: null,
-      lng: null,
-      lat: null,
+      geoLocationName: null,
+      geoLocationLng: null,
+      geoLocationLat: null,
     };
   }
 
@@ -352,7 +352,11 @@ class EditCoursePage extends React.Component {
       learner_testimonials: courseData.learner_testimonials,
       level_type: courseData.level_type,
       location_restriction: courseData.location_restriction,
-      geolocation: courseData.geolocation,
+      geolocation: {
+        location_name: courseData.geoLocationName,
+        lng: courseData.geoLocationLng,
+        lat: courseData.geoLocationLat,
+      },
       organization_logo_override: courseData.organization_logo_override_url,
       organization_short_code_override:
         courseData.organization_short_code_override,
@@ -604,6 +608,7 @@ class EditCoursePage extends React.Component {
     const imageSrc = image && image.src;
     const videoSrc = video && video.src;
     const prices = buildInitialPrices(entitlements, course_runs);
+    const geolocation = this.buildGeoLocation();
 
     return {
       title,
@@ -627,6 +632,7 @@ class EditCoursePage extends React.Component {
       type,
       url_slug,
       collaborators,
+      ...geolocation,
       course_runs: this.buildCourseRuns(),
       skill_names,
       additional_metadata: this.buildAdditionalMetadata(),
@@ -634,7 +640,6 @@ class EditCoursePage extends React.Component {
       organization_short_code_override,
       organization_logo_override_url,
       location_restriction: this.buildLocationRestriction(),
-      geolocation: this.buildGeoLocation(),
       in_year_value: this.buildInYearValue(),
     };
   }

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -312,6 +312,21 @@ class EditCoursePage extends React.Component {
     };
   }
 
+  formatGeoLocationFields(courseData) {
+    if (courseData?.geolocation) {
+      return {
+        location_name: courseData.geolocation.location_name,
+        lng: courseData.geolocation.lng,
+        lat: courseData.geolocation.lat,
+      };
+    }
+    return {
+      location_name: null,
+      lng: null,
+      lat: null,
+    };
+  }
+
   prepareSendCourseData(courseData) {
     const {
       courseInfo: {
@@ -337,6 +352,7 @@ class EditCoursePage extends React.Component {
       learner_testimonials: courseData.learner_testimonials,
       level_type: courseData.level_type,
       location_restriction: courseData.location_restriction,
+      geolocation: courseData.geolocation,
       organization_logo_override: courseData.organization_logo_override_url,
       organization_short_code_override:
         courseData.organization_short_code_override,
@@ -546,6 +562,10 @@ class EditCoursePage extends React.Component {
     return this.formatLocationRestrictionFields(this.props.courseInfo.data);
   }
 
+  buildGeoLocation() {
+    return this.formatGeoLocationFields(this.props.courseInfo.data);
+  }
+
   buildInitialValues() {
     const {
       courseInfo: {
@@ -614,6 +634,7 @@ class EditCoursePage extends React.Component {
       organization_short_code_override,
       organization_logo_override_url,
       location_restriction: this.buildLocationRestriction(),
+      geolocation: this.buildGeoLocation(),
       in_year_value: this.buildInYearValue(),
     };
   }

--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -100,11 +100,17 @@ function updateFormValuesAfterSave(change, currentFormValues, initialValues) {
   */
   return (dispatch) => {
     const {
+      geoLocationLng,
+      geoLocationLat,
       imageSrc: initialImageSrc,
       course_runs: initialCourseRuns,
     } = initialValues;
-    // This emits a redux action called CHANGE that will update currentFormValues.imageSrc
+    // This emits a redux action called CHANGE that will update currentFormValues.imageSrc,
+    // currentFormValues.geoLocationLat, and currentFormValues.geoLocationLng. Geolocation values
+    // get converted into 7 digit number on the backend and the sync is needed to get the form in clean state.
     change('imageSrc', initialImageSrc);
+    change('geoLocationLat', geoLocationLat);
+    change('geoLocationLng', geoLocationLng);
     for (let i = 0; i < initialCourseRuns.length; i += 1) {
       change(`course_runs[${i}].status`, initialCourseRuns[i].status);
     }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -86,6 +86,7 @@ const editCourseValidate = (values, props) => {
     return {};
   }
   let hasError = false;
+  let geoLocationDataCount = 0;
   const errors = {};
 
   // Validate all the fields required for submission at the top level of the form
@@ -98,15 +99,22 @@ const editCourseValidate = (values, props) => {
     }
   });
 
-  // Validate that either all or none of the geolocation fields are provided
-  const geoLocationFields = ['location_name', 'lat', 'lng'];
-  const geolocationDataCount = Object.values(values.geolocation).filter(i => i != null).length;
-  if (geolocationDataCount > 0 && geolocationDataCount < 3) {
+  // Validate that either all or none of the geolocation fields are provided.
+  // The double parsing is done to first get count of how many geoLocaton fields
+  // actually have values in them.
+  const geoLocationFields = ['geoLocationName', 'geoLocationLng', 'geoLocationLat'];
+  geoLocationFields.forEach((fieldName) => {
+    if (!values[fieldName]) {
+      geoLocationDataCount += 1;
+    }
+  });
+
+  if (geoLocationDataCount > 0 && geoLocationDataCount < 3) {
     geoLocationFields.forEach((fieldName) => {
-      const value = values.geolocation[fieldName];
+      const value = values[fieldName];
       if (!value) {
         hasError = true;
-        errors[`geolocation.${fieldName}`] = requiredMessage;
+        errors[fieldName] = requiredMessage;
       }
     });
   }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -85,7 +85,6 @@ const editCourseValidate = (values, props) => {
   if (!targetRun || targetRun.status === PUBLISHED) {
     return {};
   }
-
   let hasError = false;
   const errors = {};
 
@@ -98,6 +97,19 @@ const editCourseValidate = (values, props) => {
       errors[fieldName] = requiredMessage;
     }
   });
+
+  // Validate that either all or none of the geolocation fields are provided
+  const geoLocationFields = ['location_name', 'lat', 'lng'];
+  const geolocationDataCount = Object.values(values.geolocation).filter(i => i != null).length;
+  if (geolocationDataCount > 0 && geolocationDataCount < 3) {
+    geoLocationFields.forEach((fieldName) => {
+      const value = values.geolocation[fieldName];
+      if (!value) {
+        hasError = true;
+        errors[`geolocation.${fieldName}`] = requiredMessage;
+      }
+    });
+  }
 
   // Validate all the fields required for submission in the submitting course run
   errors.course_runs = [];

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -278,4 +278,27 @@ describe('editCourseValidate', () => {
       },
     })).toEqual({});
   });
+
+  test.each([
+    [{ geoLocationName: 'location name' }, { geoLocationLat: requiredMessage, geoLocationLng: requiredMessage }],
+    [{ geoLocationLat: '45.0' }, { geoLocationName: requiredMessage, geoLocationLng: requiredMessage }],
+    [{ geoLocationLng: '55.0' }, { geoLocationLat: requiredMessage, geoLocationName: requiredMessage }],
+    [{ geoLocationLng: '55.0', geoLocationLat: '45.0' }, { geoLocationName: requiredMessage }],
+  ])('Geolocation validation is raised if not all geolocation fields are provided', (providedGeoLocValue, expectedError) => {
+    const values = {
+      short_description: 'Short',
+      full_description: 'Full',
+      outcome: 'Outcome',
+      imageSrc: 'base64;encodedimage',
+      ...providedGeoLocValue,
+      course_runs: [
+        {
+          key: 'NonSubmittingTestRun',
+        },
+      ],
+    };
+    expect(editCourseValidate(values, { targetRun: unpublishedTargetRun })).toEqual(
+      { ...expectedError, course_runs: [null] },
+    );
+  });
 });


### PR DESCRIPTION
### [PROD-3048](https://2u-internal.atlassian.net/browse/PROD-3048)

### Description

- Add Geolocation fields on Course edit, visible to Administrator/staff only
- All 3 fields must be provided to update the data on the backend.
- Backend PR: (https://github.com/openedx/course-discovery/pull/3776) -- must be merged before merging this

### Testing
- Verify that fields are optional and  do not impact form submissions if not provided
- Verify the backend does not create/update if all 3 are not provided

<img width="904" alt="image" src="https://user-images.githubusercontent.com/40599381/214827762-f6a6cb0b-efe5-474d-b78b-e44a10804659.png">
