### PR TITLE
feat: add fields direction change option on course edit form

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink, Form } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
 
 import ReduxFormCreatableSelect from '../ReduxFormCreatableSelect';
@@ -28,7 +28,7 @@ import Collapsible from '../Collapsible';
 import PriceList from '../PriceList';
 
 import {
-  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG,
+  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG, DEFAULT_FIELDS_DIRECTION,
 } from '../../data/constants';
 import {
   titleHelp, typeHelp, urlSlugHelp, productSourceHelp,
@@ -54,6 +54,7 @@ export class BaseEditCourseForm extends React.Component {
     this.state = {
       open: false,
       collapsiblesOpen: [],
+      direction: DEFAULT_FIELDS_DIRECTION,
     };
 
     this.openCollapsible = this.openCollapsible.bind(this);
@@ -302,6 +303,12 @@ export class BaseEditCourseForm extends React.Component {
     subjectOptions.unshift({ label: '--', value: '' });
     programOptions.unshift({ label: '--', value: '' });
 
+    const toggleDirectionChange = () => {
+      this.setState(prevState => ({
+        direction: prevState.direction === 'rtl' ? 'ltr' : 'rtl',
+      }));
+    };
+
     return (
       <div className="edit-course-form">
         <form id={id} onSubmit={handleSubmit}>
@@ -315,6 +322,27 @@ export class BaseEditCourseForm extends React.Component {
             <div className="mb-3">
               <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
             </div>
+
+            <Form className="mt-4">
+              <div className="d-flex align-items-center">
+                <Form.Label>
+                  Fields Direction:
+                </Form.Label>
+                <div className="ml-5 mt-1">
+                  Left to Right
+                  <Form.Switch
+                    name="direction"
+                    value={this.state.direction === 'rtl'}
+                    className="ml-2"
+                    onChange={toggleDirectionChange}
+                    helperText="Determines the direction of the fields"
+                  >
+                    Right to left
+                  </Form.Switch>
+                </div>
+              </div>
+            </Form>
+
             <Field
               name="title"
               component={RenderInputTextField}
@@ -326,6 +354,7 @@ export class BaseEditCourseForm extends React.Component {
                   helpText={titleHelp}
                 />
               )}
+              dir={this.state.direction}
               extraInput={{ onInvalid: this.openCollapsible }}
               required
               disabled={disabled}
@@ -342,6 +371,7 @@ export class BaseEditCourseForm extends React.Component {
                   helpText={urlSlugHelp}
                 />
               )}
+              dir={this.state.direction}
               disabled={disabled || !administrator}
               optional
             />

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Hyperlink, Form } from '@edx/paragon';
+import { Hyperlink } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
 
 import ReduxFormCreatableSelect from '../ReduxFormCreatableSelect';
@@ -28,7 +28,7 @@ import Collapsible from '../Collapsible';
 import PriceList from '../PriceList';
 
 import {
-  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG, DEFAULT_FIELDS_DIRECTION,
+  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG,
 } from '../../data/constants';
 import {
   titleHelp, typeHelp, urlSlugHelp, productSourceHelp,
@@ -54,7 +54,6 @@ export class BaseEditCourseForm extends React.Component {
     this.state = {
       open: false,
       collapsiblesOpen: [],
-      direction: DEFAULT_FIELDS_DIRECTION,
     };
 
     this.openCollapsible = this.openCollapsible.bind(this);
@@ -303,12 +302,6 @@ export class BaseEditCourseForm extends React.Component {
     subjectOptions.unshift({ label: '--', value: '' });
     programOptions.unshift({ label: '--', value: '' });
 
-    const toggleDirectionChange = () => {
-      this.setState(prevState => ({
-        direction: prevState.direction === 'rtl' ? 'ltr' : 'rtl',
-      }));
-    };
-
     return (
       <div className="edit-course-form">
         <form id={id} onSubmit={handleSubmit}>
@@ -322,31 +315,10 @@ export class BaseEditCourseForm extends React.Component {
             <div className="mb-3">
               <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
             </div>
-            <Form className="mt-4">
-              <div className="d-flex align-items-center">
-                <Form.Label>
-                  Fields Direction:
-                </Form.Label>
-                <div className="ml-5 mt-1">
-                  Left to Right
-                  <Form.Switch
-                    name="direction"
-                    value={this.state.direction === 'rtl'}
-                    className="ml-2"
-                    onChange={toggleDirectionChange}
-                    helperText="Determines the direction of the fields"
-                  >
-                    Right to left
-                  </Form.Switch>
-                </div>
-              </div>
-            </Form>
-
             <Field
               name="title"
               component={RenderInputTextField}
               type="text"
-              dir={this.state.direction}
               label={(
                 <FieldLabel
                   id="title.label"
@@ -362,7 +334,6 @@ export class BaseEditCourseForm extends React.Component {
               name="url_slug"
               component={RenderInputTextField}
               type="text"
-              dir={this.state.direction}
               label={(
                 <FieldLabel
                   id="slug.label"

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink, Form } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
 
 import ReduxFormCreatableSelect from '../ReduxFormCreatableSelect';
@@ -27,7 +27,9 @@ import Pill from '../Pill';
 import Collapsible from '../Collapsible';
 import PriceList from '../PriceList';
 
-import { PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG } from '../../data/constants';
+import {
+  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG, DEFAULT_FIELDS_DIRECTION,
+} from '../../data/constants';
 import {
   titleHelp, typeHelp, urlSlugHelp, productSourceHelp,
 } from '../../helpText';
@@ -52,6 +54,7 @@ export class BaseEditCourseForm extends React.Component {
     this.state = {
       open: false,
       collapsiblesOpen: [],
+      direction: DEFAULT_FIELDS_DIRECTION,
     };
 
     this.openCollapsible = this.openCollapsible.bind(this);
@@ -300,6 +303,12 @@ export class BaseEditCourseForm extends React.Component {
     subjectOptions.unshift({ label: '--', value: '' });
     programOptions.unshift({ label: '--', value: '' });
 
+    const toggleDirectionChange = () => {
+      this.setState(prevState => ({
+        direction: prevState.direction === 'rtl' ? 'ltr' : 'rtl',
+      }));
+    };
+
     return (
       <div className="edit-course-form">
         <form id={id} onSubmit={handleSubmit}>
@@ -313,10 +322,31 @@ export class BaseEditCourseForm extends React.Component {
             <div className="mb-3">
               <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
             </div>
+            <Form className="mt-4">
+              <div className="d-flex align-items-center">
+                <Form.Label>
+                  Fields Direction:
+                </Form.Label>
+                <div className="ml-5 mt-1">
+                  Left to Right
+                  <Form.Switch
+                    name="direction"
+                    value={this.state.direction === 'rtl'}
+                    className="ml-2"
+                    onChange={toggleDirectionChange}
+                    helperText="Determines the direction of the fields"
+                  >
+                    Right to left
+                  </Form.Switch>
+                </div>
+              </div>
+            </Form>
+
             <Field
               name="title"
               component={RenderInputTextField}
               type="text"
+              dir={this.state.direction}
               label={(
                 <FieldLabel
                   id="title.label"
@@ -332,6 +362,7 @@ export class BaseEditCourseForm extends React.Component {
               name="url_slug"
               component={RenderInputTextField}
               type="text"
+              dir={this.state.direction}
               label={(
                 <FieldLabel
                   id="slug.label"

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -54,7 +54,6 @@ export class BaseEditCourseForm extends React.Component {
     this.state = {
       open: false,
       collapsiblesOpen: [],
-      direction: DEFAULT_FIELDS_DIRECTION,
     };
 
     this.openCollapsible = this.openCollapsible.bind(this);
@@ -216,6 +215,7 @@ export class BaseEditCourseForm extends React.Component {
       isSubmittingForReview,
       editable,
       courseInfo,
+      direction,
       courseInfo: {
         data: {
           skill_names: skillNames,
@@ -303,11 +303,7 @@ export class BaseEditCourseForm extends React.Component {
     subjectOptions.unshift({ label: '--', value: '' });
     programOptions.unshift({ label: '--', value: '' });
 
-    const toggleDirectionChange = () => {
-      this.setState(prevState => ({
-        direction: prevState.direction === 'rtl' ? 'ltr' : 'rtl',
-      }));
-    };
+    const fieldsDirection = direction;
 
     return (
       <div className="edit-course-form">
@@ -323,26 +319,6 @@ export class BaseEditCourseForm extends React.Component {
               <span className="text-primary-500" aria-hidden> All fields are required for publication unless otherwise specified.</span>
             </div>
 
-            <Form className="mt-4">
-              <div className="d-flex align-items-center">
-                <Form.Label>
-                  Fields Direction:
-                </Form.Label>
-                <div className="ml-5 mt-1">
-                  Left to Right
-                  <Form.Switch
-                    name="direction"
-                    value={this.state.direction === 'rtl'}
-                    className="ml-2"
-                    onChange={toggleDirectionChange}
-                    helperText="Determines the direction of the fields"
-                  >
-                    Right to left
-                  </Form.Switch>
-                </div>
-              </div>
-            </Form>
-
             <Field
               name="title"
               component={RenderInputTextField}
@@ -354,7 +330,7 @@ export class BaseEditCourseForm extends React.Component {
                   helpText={titleHelp}
                 />
               )}
-              dir={this.state.direction}
+              dir={fieldsDirection}
               extraInput={{ onInvalid: this.openCollapsible }}
               required
               disabled={disabled}
@@ -371,7 +347,7 @@ export class BaseEditCourseForm extends React.Component {
                   helpText={urlSlugHelp}
                 />
               )}
-              dir={this.state.direction}
+              dir={fieldsDirection}
               disabled={disabled || !administrator}
               optional
             />
@@ -562,7 +538,6 @@ export class BaseEditCourseForm extends React.Component {
                   extraInput={{ onInvalid: this.openCollapsible }}
                   maxChars={500}
                   id="sdesc"
-                  direction={this.state.direction}
                   disabled={disabled}
                 />
                 <Field
@@ -1279,6 +1254,7 @@ BaseEditCourseForm.propTypes = {
     isFetching: PropTypes.bool,
   }),
   modified: PropTypes.string, // last modified date (UTC formatted string)
+  direction: PropTypes.string, // determines the direction of certain fields (e.g. LTR for English, RTL for Arabic)
   courseTagOptions: PropTypes.shape({
     data: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { Hyperlink, Form } from '@edx/paragon';
+import { Hyperlink } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
 
 import ReduxFormCreatableSelect from '../ReduxFormCreatableSelect';
@@ -28,7 +28,7 @@ import Collapsible from '../Collapsible';
 import PriceList from '../PriceList';
 
 import {
-  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG, DEFAULT_FIELDS_DIRECTION,
+  PUBLISHED, REVIEWED, EXECUTIVE_EDUCATION_SLUG,
 } from '../../data/constants';
 import {
   titleHelp, typeHelp, urlSlugHelp, productSourceHelp,
@@ -1325,6 +1325,7 @@ BaseEditCourseForm.defaultProps = {
   currentFormValues: {},
   entitlement: { sku: null },
   modified: null,
+  direction: 'ltr',
   submitting: false,
   pristine: true,
   courseInReview: false,

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -562,6 +562,7 @@ export class BaseEditCourseForm extends React.Component {
                   extraInput={{ onInvalid: this.openCollapsible }}
                   maxChars={500}
                   id="sdesc"
+                  direction={this.state.direction}
                   disabled={disabled}
                 />
                 <Field

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -50,6 +50,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -109,6 +110,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -1679,6 +1681,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
+      direction="ltr"
       editable={false}
       entitlement={
         Object {
@@ -1855,6 +1858,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -1914,6 +1918,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -3484,6 +3489,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
+      direction="ltr"
       editable={false}
       entitlement={
         Object {
@@ -3698,6 +3704,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -3757,6 +3764,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -5633,6 +5641,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
+      direction="ltr"
       editable={false}
       entitlement={
         Object {
@@ -5847,6 +5856,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -5906,6 +5916,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -7476,6 +7487,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           "videoSrc": "https://www.video.src/watch?v=fdsafd",
         }
       }
+      direction="ltr"
       editable={false}
       entitlement={
         Object {
@@ -7690,6 +7702,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -7749,6 +7762,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -9271,6 +9285,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       courseTags={Array []}
       courseUuid="11111111-1111-1111-1111-111111111111"
       currentFormValues={Object {}}
+      direction="ltr"
       editable={false}
       entitlement={
         Object {
@@ -9445,6 +9460,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       </div>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -9504,6 +9520,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -11054,6 +11071,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       courseTags={Array []}
       courseUuid="11111111-1111-1111-1111-111111111111"
       currentFormValues={Object {}}
+      direction="ltr"
       editable={false}
       entitlement={
         Object {

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -48,38 +48,8 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -139,7 +109,6 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -1884,38 +1853,8 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -1975,7 +1914,6 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -3758,38 +3696,8 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -3849,7 +3757,6 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -5938,38 +5845,8 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -6029,7 +5906,6 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -7812,38 +7688,8 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -7903,7 +7749,6 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -9598,38 +9443,8 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
-      <Form
-        className="mt-4"
-        inline={false}
-      >
-        <div
-          className="d-flex align-items-center"
-        >
-          <FormLabel
-            isInline={false}
-          >
-            Fields Direction:
-          </FormLabel>
-          <div
-            className="ml-5 mt-1"
-          >
-            Left to Right
-            <ForwardRef
-              className="ml-2"
-              floatLabelLeft={false}
-              helperText="Determines the direction of the fields"
-              name="direction"
-              onChange={[Function]}
-              value={false}
-            >
-              Right to left
-            </ForwardRef>
-          </div>
-        </div>
-      </Form>
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -9689,7 +9504,6 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       />
       <Field
         component={[Function]}
-        dir="ltr"
         disabled={true}
         label={
           <FieldLabel

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -48,8 +48,38 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -109,6 +139,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -1853,8 +1884,38 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -1914,6 +1975,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -3696,8 +3758,38 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -3757,6 +3849,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -5845,8 +5938,38 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -5906,6 +6029,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -7688,8 +7812,38 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -7749,6 +7903,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel
@@ -9443,8 +9598,38 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
            All fields are required for publication unless otherwise specified.
         </span>
       </div>
+      <Form
+        className="mt-4"
+        inline={false}
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <FormLabel
+            isInline={false}
+          >
+            Fields Direction:
+          </FormLabel>
+          <div
+            className="ml-5 mt-1"
+          >
+            Left to Right
+            <ForwardRef
+              className="ml-2"
+              floatLabelLeft={false}
+              helperText="Determines the direction of the fields"
+              name="direction"
+              onChange={[Function]}
+              value={false}
+            >
+              Right to left
+            </ForwardRef>
+          </div>
+        </div>
+      </Form>
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         extraInput={
           Object {
@@ -9504,6 +9689,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
       />
       <Field
         component={[Function]}
+        dir="ltr"
         disabled={true}
         label={
           <FieldLabel

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -111,6 +112,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -253,6 +255,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -542,6 +545,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
       }
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={
         Object {
@@ -757,6 +761,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -1419,6 +1424,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
       }
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={
         Object {
@@ -1630,6 +1636,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -1709,6 +1716,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -1852,6 +1860,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -2582,6 +2591,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
       }
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={
         Object {
@@ -2793,6 +2803,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -2888,6 +2899,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -3031,6 +3043,7 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -3479,6 +3492,7 @@ exports[`EditCoursePage renders page correctly with courseOptions 1`] = `
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -3593,6 +3607,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -3676,6 +3691,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -3815,6 +3831,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -3958,6 +3975,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}
@@ -4072,6 +4090,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
         fetchCourseEditors={[Function]}
         fetchOrganizationRoles={null}
         fetchOrganizationUsers={null}
+        getFieldDirections={[Function]}
         hidden={false}
         organizationRoles={
           Object {
@@ -4155,6 +4174,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
       courseStatuses={Array []}
       courseSubmitInfo={Object {}}
       courseTags={null}
+      direction="ltr"
       editCourse={[Function]}
       entitlement={Object {}}
       fetchCollaboratorOptions={[Function]}

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -14,7 +14,7 @@ import {
 import { courseRunSubmitting } from '../../data/actions/courseSubmitInfo';
 import {
   IN_REVIEW_STATUS, PUBLISHED, REVIEW_BY_INTERNAL, REVIEW_BY_LEGAL, REVIEWED,
-  UNPUBLISHED, AUDIT_TRACK, EXECUTIVE_EDUCATION_SLUG,
+  UNPUBLISHED, AUDIT_TRACK, EXECUTIVE_EDUCATION_SLUG, DEFAULT_FIELDS_DIRECTION,
 } from '../../data/constants';
 import store from '../../data/store';
 import ConfirmationModal from '../ConfirmationModal';
@@ -28,6 +28,7 @@ class EditCoursePage extends React.Component {
       submitConfirmVisible: false,
       submitCourseData: {},
       courseTags: null,
+      direction: DEFAULT_FIELDS_DIRECTION,
     };
     this.handleCourseSubmit = this.handleCourseSubmit.bind(this);
     this.setStartedFetching = this.setStartedFetching.bind(this);
@@ -800,6 +801,13 @@ class EditCoursePage extends React.Component {
       || courseRunOptions.isFetching;
     const showForm = !showSpinner;
 
+    const getFieldDirections = (data) => {
+        console.log(data);
+        this.setState(prevState => ({
+            direction: data
+        }));
+    }     
+
     return (
       <>
         <ConfirmationModal
@@ -851,6 +859,7 @@ class EditCoursePage extends React.Component {
                       role,
                     )
                 }
+                getFieldDirections={getFieldDirections}
                 fetchOrganizationUsers={
                   !owners
                     ? null
@@ -890,6 +899,7 @@ class EditCoursePage extends React.Component {
                 entitlement={entitlement || {}}
                 title={title}
                 modified={last_modified}
+                direction={this.state.direction}
                 courseRuns={this.buildCourseRuns()}
                 uuid={uuid}
                 currentFormValues={currentFormValues}

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -806,7 +806,7 @@ class EditCoursePage extends React.Component {
       this.setState(prevState => ({
         direction: data,
       }));
-    };    
+    };
 
     return (
       <>

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -802,11 +802,11 @@ class EditCoursePage extends React.Component {
     const showForm = !showSpinner;
 
     const getFieldDirections = (data) => {
-        console.log(data);
-        this.setState(prevState => ({
-            direction: data
-        }));
-    }     
+      /* eslint-disable no-unused-vars */
+      this.setState(prevState => ({
+        direction: data,
+      }));
+    };    
 
     return (
       <>

--- a/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
+++ b/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
@@ -17,7 +17,6 @@ exports[`RenderInputTextField renders html for number type 1`] = `
     <ForwardRef
       as="input"
       autoResize={false}
-      dir="ltr"
       disabled={false}
       id="Test-text-label"
       maxLength=""
@@ -49,7 +48,6 @@ exports[`RenderInputTextField renders html for text 1`] = `
     <ForwardRef
       as="input"
       autoResize={false}
-      dir="ltr"
       disabled={false}
       id="Test-text-label"
       maxLength=""

--- a/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
+++ b/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`RenderInputTextField renders html for number type 1`] = `
     <ForwardRef
       as="input"
       autoResize={false}
+      dir="ltr"
       disabled={false}
       id="Test-text-label"
       maxLength=""
@@ -48,6 +49,7 @@ exports[`RenderInputTextField renders html for text 1`] = `
     <ForwardRef
       as="input"
       autoResize={false}
+      dir="ltr"
       disabled={false}
       id="Test-text-label"
       maxLength=""

--- a/src/components/RenderInputTextField/index.jsx
+++ b/src/components/RenderInputTextField/index.jsx
@@ -6,6 +6,7 @@ const RenderInputTextField = ({
   input,
   extraInput,
   name,
+  dir,
   label,
   type,
   disabled,
@@ -28,6 +29,7 @@ const RenderInputTextField = ({
       pattern={pattern}
       name={name}
       type={type}
+      dir={dir}
       disabled={disabled}
       required={required}
     />
@@ -47,6 +49,7 @@ RenderInputTextField.defaultProps = {
   maxLength: '',
   placeholder: '',
   pattern: null,
+  dir: 'ltr',
 };
 
 RenderInputTextField.propTypes = {
@@ -64,6 +67,7 @@ RenderInputTextField.propTypes = {
   maxLength: PropTypes.string,
   placeholder: PropTypes.string,
   pattern: PropTypes.string,
+  dir: PropTypes.string,
 };
 
 export default RenderInputTextField;

--- a/src/components/RenderInputTextField/index.jsx
+++ b/src/components/RenderInputTextField/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@edx/paragon';
-import { isRtl } from '../../utils';
 
 const RenderInputTextField = ({
   input,
@@ -29,7 +28,6 @@ const RenderInputTextField = ({
       pattern={pattern}
       name={name}
       type={type}
-      dir={isRtl(input.value) ? 'rtl' : 'ltr'}
       disabled={disabled}
       required={required}
     />
@@ -52,9 +50,7 @@ RenderInputTextField.defaultProps = {
 };
 
 RenderInputTextField.propTypes = {
-  input: PropTypes.shape({
-    value: PropTypes.string,
-  }).isRequired,
+  input: PropTypes.shape({}).isRequired,
   extraInput: PropTypes.shape({}),
   name: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,

--- a/src/components/RenderInputTextField/index.jsx
+++ b/src/components/RenderInputTextField/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@edx/paragon';
+import { isRtl } from '../../utils';
 
 const RenderInputTextField = ({
   input,
   extraInput,
   name,
-  dir,
   label,
   type,
   disabled,
@@ -29,7 +29,7 @@ const RenderInputTextField = ({
       pattern={pattern}
       name={name}
       type={type}
-      dir={dir}
+      dir={isRtl(input.value) ? 'rtl' : 'ltr'}
       disabled={disabled}
       required={required}
     />
@@ -49,11 +49,12 @@ RenderInputTextField.defaultProps = {
   maxLength: '',
   placeholder: '',
   pattern: null,
-  dir: 'ltr',
 };
 
 RenderInputTextField.propTypes = {
-  input: PropTypes.shape({}).isRequired,
+  input: PropTypes.shape({
+    value: PropTypes.string,
+  }).isRequired,
   extraInput: PropTypes.shape({}),
   name: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
@@ -67,7 +68,6 @@ RenderInputTextField.propTypes = {
   maxLength: PropTypes.string,
   placeholder: PropTypes.string,
   pattern: PropTypes.string,
-  dir: PropTypes.string,
 };
 
 export default RenderInputTextField;

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -24,14 +24,12 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
-          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language directionality",
-          "selector": "textarea",
+          "plugins": "legacyoutput link lists language",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
         }
       }
       initialValue={null}
@@ -73,14 +71,12 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
-          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language directionality",
-          "selector": "textarea",
+          "plugins": "legacyoutput link lists language",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
         }
       }
       initialValue="<p>Prior text<p>"
@@ -120,14 +116,12 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
-          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language directionality",
-          "selector": "textarea",
+          "plugins": "legacyoutput link lists language",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
         }
       }
       initialValue={null}
@@ -169,14 +163,12 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
-          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language directionality",
-          "selector": "textarea",
+          "plugins": "legacyoutput link lists language",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
         }
       }
       initialValue="<p>Prior text<p>"

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -24,12 +24,14 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
+          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue={null}
@@ -71,12 +73,14 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
+          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"
@@ -116,12 +120,14 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
+          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue={null}
@@ -163,12 +169,14 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
           "content_css": false,
           "content_style": "",
           "default_link_target": "_blank",
+          "directionality": "ltr",
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
           "plugins": "legacyoutput link lists language directionality",
           "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language| ltr rtl",
         }
       }
       initialValue={null}
@@ -80,7 +80,7 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
           "plugins": "legacyoutput link lists language directionality",
           "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language| ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"
@@ -127,7 +127,7 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
           "plugins": "legacyoutput link lists language directionality",
           "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language| ltr rtl",
         }
       }
       initialValue={null}
@@ -176,7 +176,7 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
           "plugins": "legacyoutput link lists language directionality",
           "selector": "textarea",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language| ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -16,6 +16,8 @@ import contentCss from 'tinymce/skins/content/default/content.min.css';
 import contentUiCss from 'tinymce/skins/ui/oxide/content.min.css';
 import { Alert } from '@edx/paragon';
 
+import { isRtl, removeHtmlTags } from '../../utils';
+
 class RichEditor extends React.Component {
   constructor(props) {
     super(props);
@@ -93,7 +95,7 @@ class RichEditor extends React.Component {
               plugins: 'legacyoutput link lists language directionality',
               statusbar: false,
               toolbar: 'undo redo | bold italic underline | bullist numlist | link | language | ltr rtl',
-              directionality: 'ltr',
+              directionality: isRtl(removeHtmlTags(value)) ? 'rtl' : 'ltr',
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -9,6 +9,7 @@ import 'tinymce/plugins/legacyoutput';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/themes/silver/theme';
+import 'tinymce/plugins/directionality';
 import '@edx/tinymce-language-selector';
 import 'tinymce/skins/ui/oxide/skin.css';
 import contentCss from 'tinymce/skins/content/default/content.min.css';
@@ -88,9 +89,11 @@ class RichEditor extends React.Component {
             init={{
               branding: false,
               menubar: false,
-              plugins: 'legacyoutput link lists language',
+              selector: 'textarea',
+              plugins: 'legacyoutput link lists language directionality',
               statusbar: false,
-              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language',
+              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language | ltr rtl',
+              directionality: 'ltr',
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -9,14 +9,11 @@ import 'tinymce/plugins/legacyoutput';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/themes/silver/theme';
-import 'tinymce/plugins/directionality';
 import '@edx/tinymce-language-selector';
 import 'tinymce/skins/ui/oxide/skin.css';
 import contentCss from 'tinymce/skins/content/default/content.min.css';
 import contentUiCss from 'tinymce/skins/ui/oxide/content.min.css';
 import { Alert } from '@edx/paragon';
-
-import { isRtl, removeHtmlTags } from '../../utils';
 
 class RichEditor extends React.Component {
   constructor(props) {
@@ -91,11 +88,9 @@ class RichEditor extends React.Component {
             init={{
               branding: false,
               menubar: false,
-              selector: 'textarea',
-              plugins: 'legacyoutput link lists language directionality',
+              plugins: 'legacyoutput link lists language',
               statusbar: false,
-              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language | ltr rtl',
-              directionality: isRtl(removeHtmlTags(value)) ? 'rtl' : 'ltr',
+              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language',
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -36,7 +36,7 @@ class RichEditor extends React.Component {
       this.setState({
         direction,
       });
-      /* eslint prefer-destructuring: ["error", {VariableDeclarator: {object: true}}] */
+      /* eslint-disable-next-line prefer-destructuring */
       const editor = this.editorRef.current.editor;
       // set the direction
       editor.getBody().dir = direction;
@@ -73,7 +73,6 @@ class RichEditor extends React.Component {
         error,
       },
       disabled,
-      direction,
     } = this.props;
     const remainingChars = maxChars - this.state.charCount;
     const characterLimitMessage = `Recommended character limit (including spaces) is

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -21,10 +21,33 @@ class RichEditor extends React.Component {
     super(props);
     this.state = {
       charCount: 0,
+      direction: props.direction,
     };
+    this.editorRef = React.createRef();
     this.initCharCount = this.initCharCount.bind(this);
     this.updateCharCount = this.updateCharCount.bind(this);
   }
+
+  componentDidUpdate(prevProps) {
+        const {
+        direction,
+        } = this.props;
+        if (direction !== prevProps.direction) {
+            this.setState({
+                direction,
+            });
+        const editor = this.editorRef.current.editor;
+        console.log('mera editor', editor);
+        // set the direction
+        editor.getBody().dir = direction;
+        // set the direction of the toolbar
+        // editor.getContainer().dir = direction;
+        }
+        // get the editor instance
+        
+        // // set the direction of the statusbar
+        // editor.theme.panel.find('#' + editor.id + '-statusbar').attr('dir', direction);
+    }
 
   initCharCount(event, editor) {
     const content = editor.getContent({ format: 'text' });
@@ -56,6 +79,7 @@ class RichEditor extends React.Component {
         error,
       },
       disabled,
+      direction,
     } = this.props;
     const remainingChars = maxChars - this.state.charCount;
     const characterLimitMessage = `Recommended character limit (including spaces) is
@@ -68,6 +92,10 @@ class RichEditor extends React.Component {
     } catch (err) {
       contentStyle = '';
     }
+
+    const editorDirection = direction === 'rtl' ? 'rtl' : 'ltr';
+    // const editorDirection = 'rtl';
+    // console.log('editorDirection', editorDirection, name, direction);
 
     return (
       <div className="form-group">
@@ -86,14 +114,15 @@ class RichEditor extends React.Component {
         <div aria-labelledby={id} className={classNames({ 'disabled-rich-text': disabled })}>
           <Editor
             initialValue={value}
+            ref={this.editorRef}
             init={{
               branding: false,
               menubar: false,
               selector: 'textarea',
               plugins: 'legacyoutput link lists language directionality',
               statusbar: false,
-              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language | ltr rtl',
-              directionality: 'ltr',
+              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language| ltr rtl',
+              directionality: editorDirection,
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,
@@ -115,6 +144,7 @@ class RichEditor extends React.Component {
 RichEditor.defaultProps = {
   maxChars: null,
   disabled: false,
+  direction: 'ltr',
 };
 
 RichEditor.propTypes = {
@@ -132,6 +162,7 @@ RichEditor.propTypes = {
     error: PropTypes.string,
   }).isRequired,
   disabled: PropTypes.bool,
+  direction: PropTypes.string,
 };
 
 export default RichEditor;

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -36,6 +36,7 @@ class RichEditor extends React.Component {
       this.setState({
         direction,
       });
+      /* eslint prefer-destructuring: ["error", {VariableDeclarator: {object: true}}] */
       const editor = this.editorRef.current.editor;
       // set the direction
       editor.getBody().dir = direction;
@@ -86,8 +87,6 @@ class RichEditor extends React.Component {
       contentStyle = '';
     }
 
-    const editorDirection = direction === 'rtl' ? 'rtl' : 'ltr';
-
     return (
       <div className="form-group">
         <div id={id} name={name} tabIndex="-1" className="mb-2">{label}</div>
@@ -113,7 +112,7 @@ class RichEditor extends React.Component {
               plugins: 'legacyoutput link lists language directionality',
               statusbar: false,
               toolbar: 'undo redo | bold italic underline | bullist numlist | link | language| ltr rtl',
-              directionality: editorDirection,
+              directionality: this.state.direction,
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -29,25 +29,18 @@ class RichEditor extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-        const {
+    const {
+      direction,
+    } = this.props;
+    if (direction !== prevProps.direction) {
+      this.setState({
         direction,
-        } = this.props;
-        if (direction !== prevProps.direction) {
-            this.setState({
-                direction,
-            });
-        const editor = this.editorRef.current.editor;
-        console.log('mera editor', editor);
-        // set the direction
-        editor.getBody().dir = direction;
-        // set the direction of the toolbar
-        // editor.getContainer().dir = direction;
-        }
-        // get the editor instance
-        
-        // // set the direction of the statusbar
-        // editor.theme.panel.find('#' + editor.id + '-statusbar').attr('dir', direction);
+      });
+      const editor = this.editorRef.current.editor;
+      // set the direction
+      editor.getBody().dir = direction;
     }
+  }
 
   initCharCount(event, editor) {
     const content = editor.getContent({ format: 'text' });
@@ -94,8 +87,6 @@ class RichEditor extends React.Component {
     }
 
     const editorDirection = direction === 'rtl' ? 'rtl' : 'ltr';
-    // const editorDirection = 'rtl';
-    // console.log('editorDirection', editorDirection, name, direction);
 
     return (
       <div className="form-group">

--- a/src/components/SidePanes/LanguageConfigPane.jsx
+++ b/src/components/SidePanes/LanguageConfigPane.jsx
@@ -20,7 +20,8 @@ const LanguageConfigPane = ({
 
   useEffect(() => {
     getLanguageConfig(languageConfig ? 'rtl' : 'ltr');
-  }, [languageConfig, getLanguageConfig]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [languageConfig]);
 
   return (
     <Pane className="mt-1" title="Language Configuration" info="Select the language configuration for the course.">

--- a/src/components/SidePanes/LanguageConfigPane.jsx
+++ b/src/components/SidePanes/LanguageConfigPane.jsx
@@ -50,4 +50,8 @@ LanguageConfigPane.propTypes = {
   getLanguageConfig: PropTypes.func,
 };
 
+LanguageConfigPane.defaultProps = {
+    getLanguageConfig: () => {},
+};
+
 export default LanguageConfigPane;

--- a/src/components/SidePanes/LanguageConfigPane.jsx
+++ b/src/components/SidePanes/LanguageConfigPane.jsx
@@ -51,7 +51,7 @@ LanguageConfigPane.propTypes = {
 };
 
 LanguageConfigPane.defaultProps = {
-    getLanguageConfig: () => {},
+  getLanguageConfig: () => {},
 };
 
 export default LanguageConfigPane;

--- a/src/components/SidePanes/LanguageConfigPane.jsx
+++ b/src/components/SidePanes/LanguageConfigPane.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form, Spinner } from '@edx/paragon';
+
+import Pane from './Pane';
+
+const LanguageConfigPane = ({ 
+  getLanguageConfig,
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [languageConfig, setLanguageConfig] = useState(false);
+
+  const toggleLanguageConfig = () => {
+    setIsLoading(true);
+    setLanguageConfig(!languageConfig);
+    setError(null);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    getLanguageConfig(languageConfig ? 'rtl' : 'ltr');
+  }, [languageConfig]);
+
+  return (
+    <Pane className="mt-1" title="Language Configuration" info="Select the language configuration for the course.">
+      <Form className="mt-1">
+        <Form.Label>
+          Fields Direction:
+        </Form.Label>
+        <div className="mt-1">
+          Left to Right
+          <Form.Switch
+            name="direction"
+            value={languageConfig}
+            className="ml-2"
+            onChange={toggleLanguageConfig}
+          >
+            Right to left
+          </Form.Switch>
+        </div>
+        {isLoading && <Spinner className="ml-2" />}
+        {error && <div className="text-danger">{error}</div>}
+      </Form>
+    </Pane>
+  );
+};
+
+LanguageConfigPane.propTypes = {
+  getLanguageConfig: PropTypes.func,
+};
+
+export default LanguageConfigPane;

--- a/src/components/SidePanes/LanguageConfigPane.jsx
+++ b/src/components/SidePanes/LanguageConfigPane.jsx
@@ -4,7 +4,7 @@ import { Form, Spinner } from '@edx/paragon';
 
 import Pane from './Pane';
 
-const LanguageConfigPane = ({ 
+const LanguageConfigPane = ({
   getLanguageConfig,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -20,7 +20,7 @@ const LanguageConfigPane = ({
 
   useEffect(() => {
     getLanguageConfig(languageConfig ? 'rtl' : 'ltr');
-  }, [languageConfig]);
+  }, [languageConfig, getLanguageConfig]);
 
   return (
     <Pane className="mt-1" title="Language Configuration" info="Select the language configuration for the course.">

--- a/src/components/SidePanes/index.jsx
+++ b/src/components/SidePanes/index.jsx
@@ -5,6 +5,7 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import UsersPane from './UsersPane';
 import CommentsPane from './CommentsPane';
 import CatalogInclusionPane from './CatalogInclusionPane';
+import LanguageConfigPane from './LanguageConfigPane';
 
 const SidePanes = (props) => {
   const isEdxStaff = getAuthenticatedUser().administrator;
@@ -14,6 +15,10 @@ const SidePanes = (props) => {
     const incList = props.organizations.map(element => element.enterprise_subscription_inclusion);
     orgInclusionList = incList.every(orgInclusion => orgInclusion === true);
   }
+
+  const getLanguageConfig = (data) => {
+    props.getFieldDirections(data);
+  };
 
   return (
     <div className={props.className} hidden={props.hidden}>
@@ -26,6 +31,9 @@ const SidePanes = (props) => {
         organizationRoles={props.organizationRoles}
         organizationUsers={props.organizationUsers}
         removeCourseEditor={props.removeCourseEditor}
+      />
+      <LanguageConfigPane
+        getLanguageConfig={getLanguageConfig}
       />
       { isEdxStaff && (
       <CatalogInclusionPane
@@ -61,6 +69,7 @@ SidePanes.defaultProps = {
   organizationRoles: {},
   organizationUsers: {},
   removeCourseEditor: () => null,
+  getFieldDirections: () => null,
 };
 
 SidePanes.propTypes = {
@@ -76,6 +85,7 @@ SidePanes.propTypes = {
   fetchCourseEditors: PropTypes.func,
   fetchOrganizationRoles: PropTypes.func,
   fetchOrganizationUsers: PropTypes.func,
+  getFieldDirections: PropTypes.func,
   hidden: PropTypes.bool,
   organizations: PropTypes.arrayOf(PropTypes.string),
   organizationRoles: PropTypes.shape(),

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -21,6 +21,7 @@ const FORMAT_DATE_MATCHER = /20\d{2}-(0\d{1}|1[0-2])-([0-2]\d{1}|3[0-1])/;
 const NORMALIZE_DATE_MATCHER = /20\d{2}\/(0\d{1}|1[0-2])\/([0-2]\d{1}|3[0-1])/;
 
 const EXECUTIVE_EDUCATION_SLUG = 'executive-education-2u';
+const DEFAULT_FIELDS_DIRECTION = 'ltr';
 
 export {
   VERIFIED_TRACK,
@@ -43,4 +44,5 @@ export {
   COURSE_EXEMPT_FIELDS,
   COURSE_RUN_NON_EXEMPT_FIELDS,
   EXECUTIVE_EDUCATION_SLUG,
+  DEFAULT_FIELDS_DIRECTION,
 };

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -21,12 +21,6 @@ const FORMAT_DATE_MATCHER = /20\d{2}-(0\d{1}|1[0-2])-([0-2]\d{1}|3[0-1])/;
 const NORMALIZE_DATE_MATCHER = /20\d{2}\/(0\d{1}|1[0-2])\/([0-2]\d{1}|3[0-1])/;
 
 const EXECUTIVE_EDUCATION_SLUG = 'executive-education-2u';
-const DEFAULT_FIELDS_DIRECTION = 'ltr';
-
-// regex matching RTL characters (Hebrew, Arabic, etc.)
-const RTL_CHARS_REGEX = /[\u0590-\u08FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
-// regex matching LTR characters
-const LTR_CHARS_REGEX = /[A-Za-z\u00C0-\u024F\u1E00-\u1EFF]/;
 
 export {
   VERIFIED_TRACK,
@@ -49,7 +43,4 @@ export {
   COURSE_EXEMPT_FIELDS,
   COURSE_RUN_NON_EXEMPT_FIELDS,
   EXECUTIVE_EDUCATION_SLUG,
-  DEFAULT_FIELDS_DIRECTION,
-  LTR_CHARS_REGEX,
-  RTL_CHARS_REGEX,
 };

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -23,6 +23,11 @@ const NORMALIZE_DATE_MATCHER = /20\d{2}\/(0\d{1}|1[0-2])\/([0-2]\d{1}|3[0-1])/;
 const EXECUTIVE_EDUCATION_SLUG = 'executive-education-2u';
 const DEFAULT_FIELDS_DIRECTION = 'ltr';
 
+// regex matching RTL characters (Hebrew, Arabic, etc.)
+const RTL_CHARS_REGEX = /[\u0590-\u08FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
+// regex matching LTR characters
+const LTR_CHARS_REGEX = /[A-Za-z\u00C0-\u024F\u1E00-\u1EFF]/;
+
 export {
   VERIFIED_TRACK,
   AUDIT_TRACK,
@@ -45,4 +50,6 @@ export {
   COURSE_RUN_NON_EXEMPT_FIELDS,
   EXECUTIVE_EDUCATION_SLUG,
   DEFAULT_FIELDS_DIRECTION,
+  LTR_CHARS_REGEX,
+  RTL_CHARS_REGEX,
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,7 +5,7 @@ import qs from 'query-string';
 
 import history from '../data/history';
 import {
-  COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, MASTERS_TRACK, LTR_CHARS_REGEX, RTL_CHARS_REGEX,
+  COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, MASTERS_TRACK,
 } from '../data/constants';
 import DiscoveryDataApiService from '../data/services/DiscoveryDataApiService';
 import { PAGE_SIZE } from '../data/constants/table';
@@ -29,20 +29,6 @@ const isValidDate = (dateStr) => {
   const date = moment(dateStr);
   return moment(dateStr) && date.isValid();
 };
-
-function isRtl(text) {
-  const rtlChars = RTL_CHARS_REGEX;
-  const ltrChars = LTR_CHARS_REGEX;
-
-  return rtlChars.test(text) && !ltrChars.test(text);
-}
-
-function removeHtmlTags(htmlText) {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlText, 'text/html');
-  const plainText = doc.body.textContent || '';
-  return plainText;
-}
 
 const updateUrl = (queryOptions) => {
   if (!queryOptions) {
@@ -358,13 +344,11 @@ export {
   localTimeZone,
   utcTimeZone,
   isSafari,
-  isRtl,
   isNonExemptChanged,
   isPristine,
   parseOptions,
   getOptionsData,
   parseCourseTypeOptions,
-  removeHtmlTags,
   formatPriceData,
   buildInitialPrices,
   hasMastersTrack,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,7 +4,9 @@ import 'moment-timezone';
 import qs from 'query-string';
 
 import history from '../data/history';
-import { COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, MASTERS_TRACK } from '../data/constants';
+import {
+  COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, MASTERS_TRACK, LTR_CHARS_REGEX, RTL_CHARS_REGEX,
+} from '../data/constants';
 import DiscoveryDataApiService from '../data/services/DiscoveryDataApiService';
 import { PAGE_SIZE } from '../data/constants/table';
 
@@ -27,6 +29,20 @@ const isValidDate = (dateStr) => {
   const date = moment(dateStr);
   return moment(dateStr) && date.isValid();
 };
+
+function isRtl(text) {
+  const rtlChars = RTL_CHARS_REGEX;
+  const ltrChars = LTR_CHARS_REGEX;
+
+  return rtlChars.test(text) && !ltrChars.test(text);
+}
+
+function removeHtmlTags(htmlText) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlText, 'text/html');
+  const plainText = doc.body.textContent || '';
+  return plainText;
+}
 
 const updateUrl = (queryOptions) => {
   if (!queryOptions) {
@@ -342,11 +358,13 @@ export {
   localTimeZone,
   utcTimeZone,
   isSafari,
+  isRtl,
   isNonExemptChanged,
   isPristine,
   parseOptions,
   getOptionsData,
   parseCourseTypeOptions,
+  removeHtmlTags,
   formatPriceData,
   buildInitialPrices,
   hasMastersTrack,


### PR DESCRIPTION
Description:
-------------
[PROD-3220] (https://2u-internal.atlassian.net/browse/PROD-3220)

- Demo is in Ticket description

Testing:
In order to test the changes on local
- Fetch backed Discovery discovery changes PR (to allow direction attr to add in p tag) https://github.com/openedx/course-discovery/pull/3908
- Run `discovery`, `frontend-app-publisher` and `studio` containers on local
- Go to edit course page
- Verify direction of `title` and `url_slug` changing on switching the switch button 
- Plus check directionality plugin working for `tinymce` editor

> Will add these changes to create course form as well, once i got review from the team 

##### Snapshot:
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/78806673/236929727-aa6c1435-68b3-45d1-aeee-e2e702077e41.png">


Vedio Demo:

https://user-images.githubusercontent.com/78806673/234691580-c8098a24-bcbd-487e-89c6-ce7b3f36f4c7.mp4

