### PR TITLE
chore: update url slug tooltip

### DIFF
--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -117,6 +117,11 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
             helpText={
               <div>
                 <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
+                <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>
                 <p>
@@ -1916,6 +1921,11 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
             extraText=""
             helpText={
               <div>
+                <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
                 <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>
@@ -3754,6 +3764,11 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
             extraText=""
             helpText={
               <div>
+                <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
                 <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>
@@ -5899,6 +5914,11 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
             helpText={
               <div>
                 <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
+                <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>
                 <p>
@@ -7737,6 +7757,11 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
             helpText={
               <div>
                 <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
+                <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>
                 <p>
@@ -9486,6 +9511,11 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
             extraText=""
             helpText={
               <div>
+                <p>
+                  <b>
+                    Note: Course editors cannot edit the URL slug. Please reach out to your project coordinator or edX support to edit this field.
+                  </b>
+                </p>
                 <p>
                   This field is optional. If left blank, edX will automatically create a URL slug based on the course title.
                 </p>

--- a/src/helpText.jsx
+++ b/src/helpText.jsx
@@ -188,6 +188,12 @@ const productSourceHelp = (
 const urlSlugHelp = (
   <div>
     <p>
+      <b>
+        Note: Course editors cannot edit the URL slug.
+        Please reach out to your project coordinator or edX support to edit this field.
+      </b>
+    </p>
+    <p>
       This field is optional. If left blank, edX will automatically
       create a URL slug based on the course title.
     </p>


### PR DESCRIPTION
[PROD-3240](https://2u-internal.atlassian.net/browse/PROD-3240)
This PRs updates `url slug` tooltip message on Course Edit Page

#### Snapshot:
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/78806673/234889696-9cd9667a-4ff8-4f62-b406-534150340d42.png">

