### PR TITLE
fix: add redux change to update fields changed by backend

### DIFF
--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -94,25 +94,46 @@ function clearCreateCourseStatus() {
 
 function updateFormValuesAfterSave(change, currentFormValues, initialValues) {
   /*
-    We need to overwrite imageSrc and course run statuses because they are changed
+    We need to overwrite different fields because they are changed
     in the backend so the form does not have the updated values by default.
     * This will allow the form to return to being pristine after saving. *
+    1. imageSrc
+    2. course run statuses & transcript_languages
+    3. geolocation co-ordinates
+      Geolocation values convert to 7 digit number on the backend and the sync is needed to get in clean state.
+    4. url_slug: Auto-generated on backend if not provided
+    5. tags: To maintain ordering returned by the backend
+    6. in_year_value: each dict key has default backend value which is not read by form unless changed.
   */
   return (dispatch) => {
     const {
       geoLocationLng,
       geoLocationLat,
+      tags,
+      url_slug: urlSlug,
       imageSrc: initialImageSrc,
       course_runs: initialCourseRuns,
+      in_year_value: {
+        per_lead_usa: perLeadUSA,
+        per_lead_international: perLeadInternational,
+        per_click_usa: perClickUSA,
+        per_click_international: perClicknternational,
+      },
     } = initialValues;
-    // This emits a redux action called CHANGE that will update currentFormValues.imageSrc,
-    // currentFormValues.geoLocationLat, and currentFormValues.geoLocationLng. Geolocation values
-    // get converted into 7 digit number on the backend and the sync is needed to get the form in clean state.
+
+    // This emits a redux action called CHANGE that will update:
     change('imageSrc', initialImageSrc);
     change('geoLocationLat', geoLocationLat);
     change('geoLocationLng', geoLocationLng);
+    change('tags', tags);
+    change('url_slug', urlSlug);
+    change('in_year_value.per_lead_usa', perLeadUSA);
+    change('in_year_value.per_lead_international', perLeadInternational);
+    change('in_year_value.per_click_usa', perClickUSA);
+    change('in_year_value.per_click_international', perClicknternational);
     for (let i = 0; i < initialCourseRuns.length; i += 1) {
       change(`course_runs[${i}].status`, initialCourseRuns[i].status);
+      change(`course_runs[${i}].transcript_languages`, initialCourseRuns[i].transcript_languages);
     }
     // Need to reset courseInfo.courseSaved to false so we don't continuously
     // overwrite the currentFormValues.

--- a/src/data/actions/courseInfo.test.js
+++ b/src/data/actions/courseInfo.test.js
@@ -20,6 +20,7 @@ import {
   editCourseFail,
   clearCourseSaved,
   setCreateAlertOff,
+  updateFormValuesAfterSave,
 } from './courseInfo';
 import * as types from '../constants/courseInfo';
 
@@ -186,6 +187,43 @@ describe('courseInfo edit course actions', () => {
   it('should call clear course saved', () => {
     const expectedAction = { type: types.CLEAR_COURSE_SAVED };
     expect(clearCourseSaved()).toEqual(expectedAction);
+  });
+
+  it('form value update after save is called with passed change method', () => {
+    const changeMock = jest.fn();
+    const store = mockStore();
+    const formValues = {
+      geoLocationLng: '45.0000',
+      geoLocationLat: '50.0000',
+      url_slug: 'test_slug',
+      tags: ['tag1', 'tag2'],
+      in_year_value: {
+        per_lead_usa: 10,
+        per_lead_international: 20,
+        per_click_usa: 25,
+        per_click_international: 30,
+      },
+      imageSrc: 'http://updated.image.src/woo.small',
+      course_runs: [
+        {
+          status: 'published',
+          transcript_languages: ['en-us'],
+        },
+      ],
+    };
+    store.dispatch(updateFormValuesAfterSave(changeMock, formValues, formValues));
+
+    expect(changeMock).toHaveBeenNthCalledWith(1, 'imageSrc', 'http://updated.image.src/woo.small');
+    expect(changeMock).toHaveBeenNthCalledWith(2, 'geoLocationLat', '50.0000');
+    expect(changeMock).toHaveBeenNthCalledWith(3, 'geoLocationLng', '45.0000');
+    expect(changeMock).toHaveBeenNthCalledWith(4, 'tags', ['tag1', 'tag2']);
+    expect(changeMock).toHaveBeenNthCalledWith(5, 'url_slug', 'test_slug');
+    expect(changeMock).toHaveBeenNthCalledWith(6, 'in_year_value.per_lead_usa', 10);
+    expect(changeMock).toHaveBeenNthCalledWith(7, 'in_year_value.per_lead_international', 20);
+    expect(changeMock).toHaveBeenNthCalledWith(8, 'in_year_value.per_click_usa', 25);
+    expect(changeMock).toHaveBeenNthCalledWith(9, 'in_year_value.per_click_international', 30);
+    expect(changeMock).toHaveBeenNthCalledWith(10, 'course_runs[0].status', 'published');
+    expect(changeMock).toHaveBeenNthCalledWith(11, 'course_runs[0].transcript_languages', ['en-us']);
   });
 });
 


### PR DESCRIPTION
### [PROD-3256](https://2u-internal.atlassian.net/browse/PROD-3256)

### Description

In certain cases of edits, the Save & Re-publish would not change to the disabled "Changes Saved" button after the API call has been completed. This happens when the backend has changed the form values in one way or another in the returned response. On publisher, if the form values do not match returned values, it treats as if the edits are still in progress. That is also why refreshing the page fixed the button because form values are populated with the latest DB data returned by API. 
This PR adds a few fields, that can be edited by backend, to sync their data with form data via a redux change to ensure the button moves to the correct state and provide feedback to the editor that the operation was successful.

### Testing
- Run publisher on your local. Make sure studio, ecommerce, and discovery are also running.
- Open a course that has values against most fields.
- Set url_slug to empty, remove focus, and press "Save & Re-publish". Notice the slug field gets populated with data
- Add/Remove topics and repeat. Ensure the order of tags is the same.
- Add values for 1-2 fields for In Year value section. Ensure the default values from the backend are populated for other fields after saving.
- Under transcript lang, add English and then add Arabic. After save, Arabic will be above English and button will change.