### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dist/
 
 .idea
 .vscode
+
+# i18n generated artifacts
+/temp/
+/src/i18n/transifex_input.json

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,18 @@
 # already shelled into the container using the `make frontend-app-publisher-shell`
 # command in devstack
 
+intl_imports = ./node_modules/.bin/intl-imports.js
+transifex_utils = ./node_modules/.bin/transifex-utils.js
+i18n = ./src/i18n
+transifex_input = $(i18n)/transifex_input.json
+
+# This directory must match .babelrc .
+transifex_temp = ./temp/babel-plugin-react-intl
+
+
+requirements:
+	npm install
+
 npm-install-%: ## install specified % npm package on the cookie-cutter container
 	npm install $* --save-dev
 	git add package.json
@@ -20,3 +32,26 @@ lint:
 
 eslint-fix:
 	bash -c 'npm run lint-fix'
+
+
+i18n.extract:
+	# Pulling display strings from .jsx files into .json files...
+	rm -rf $(transifex_temp)
+	npm run-script i18n_extract
+
+i18n.concat:
+	# Gathering JSON messages into one file...
+	$(transifex_utils) $(transifex_temp) $(transifex_input)
+
+extract_translations: | requirements i18n.extract i18n.concat
+
+pull_translations:  ## Pull translations using atlas
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+	   && atlas pull --filter=$(transifex_langs) \
+	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+	            translations/paragon/src/i18n/messages:paragon \
+	            translations/frontend-app-publisher/src/i18n/messages:frontend-app-publisher
+
+	$(intl_imports) frontend-component-footer paragon frontend-app-publisher

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-        "@edx/frontend-component-footer-edx": "^6.0.0",
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-component-footer": "npm:@edx/frontend-component-footer-edx@^6.0.0",
+        "@edx/frontend-platform": "^4.2.0",
         "@edx/paragon": "^20.20.0",
         "@edx/tinymce-language-selector": "1.1.0",
         "@fortawesome/free-regular-svg-icons": "6.1.1",
@@ -2140,7 +2140,8 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/@edx/frontend-component-footer-edx": {
+    "node_modules/@edx/frontend-component-footer": {
+      "name": "@edx/frontend-component-footer-edx",
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer-edx/-/frontend-component-footer-edx-6.0.0.tgz",
       "integrity": "sha512-j0pWuwtX7OlSZXhfmAw7nOO4zesfRSARTtm4Sw9azq8Gxeo0gcvZ+iH8iIU6+wqSAlv5fOLgpWT0bPeoNmVgMQ==",
@@ -2160,7 +2161,7 @@
         "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
-    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/free-regular-svg-icons": {
+    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-regular-svg-icons": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
       "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
@@ -2172,7 +2173,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/free-solid-svg-icons": {
+    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
       "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
@@ -2184,7 +2185,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/@edx/frontend-component-footer-edx/node_modules/@fortawesome/react-fontawesome": {
+    "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/react-fontawesome": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
       "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
@@ -2197,9 +2198,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.0.1.tgz",
-      "integrity": "sha512-79uo/iQJ7P1tIY0MHTQ874W/NrNkcDe4BFC/0AvKF4DNrkqq9AkUFKqQ3hvd8E9C1EK189KlcAmo6FFQ67IFXg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
+      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -2222,13 +2223,14 @@
         "universal-cookie": "4.0.4"
       },
       "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
         "@edx/paragon": ">= 10.0.0 < 21.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
         "react-redux": "^7.1.1",
         "react-router-dom": "^5.0.1",
         "redux": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "description": "Frontend for the Publisher Application",
   "repository": "https://github.com/openedx/frontend-app-publisher",
-  "browserslist": ["extends @edx/browserslist-config"],
+  "browserslist": [
+    "extends @edx/browserslist-config"
+  ],
   "scripts": {
     "build": "fedx-scripts webpack",
+    "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "deploy:gh-pages": "npm run build && gh-pages -d dist",
     "lint": "fedx-scripts eslint --ext .jsx,.js .",
     "lint-fix": "fedx-scripts eslint --ext .jsx,.js . --fix",
@@ -20,8 +23,8 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-    "@edx/frontend-component-footer-edx": "^6.0.0",
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-component-footer": "npm:@edx/frontend-component-footer-edx@^6.0.0",
+    "@edx/frontend-platform": "^4.2.0",
     "@edx/paragon": "^20.20.0",
     "@edx/tinymce-language-selector": "1.1.0",
     "@fortawesome/free-regular-svg-icons": "6.1.1",

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -5,6 +5,7 @@ import { mount, shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import configureStore from 'redux-mock-store';
 import { Alert } from '@edx/paragon';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import EditCoursePage from './index';
 
@@ -889,12 +890,14 @@ describe('EditCoursePage', () => {
       const EditCoursePageWrapper = (props) => (
         <MemoryRouter>
           <Provider store={mockStore()}>
-            <EditCoursePage
-              {...props}
-              courseInfo={courseInfo}
-              courseOptions={courseOptions}
-              courseRunOptions={courseRunOptions}
-            />
+            <IntlProvider locale="en">
+              <EditCoursePage
+                {...props}
+                courseInfo={courseInfo}
+                courseOptions={courseOptions}
+                courseRunOptions={courseRunOptions}
+              />
+            </IntlProvider>
           </Provider>
         </MemoryRouter>
       );

--- a/src/components/Pill/Pill.test.jsx
+++ b/src/components/Pill/Pill.test.jsx
@@ -1,30 +1,37 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowToJson } from 'enzyme-to-json';
+import { render } from 'enzyme';
+import { renderToJson } from 'enzyme-to-json';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import Pill from './index';
 
+const PillWrapper = (props) => (
+  <IntlProvider locale="en">
+    <Pill {...props} />
+  </IntlProvider>
+);
+
 describe('Pill', () => {
   it('renders without any statuses', () => {
-    const component = shallow(<Pill statuses={[]} />);
-    expect(shallowToJson(component)).toMatchSnapshot();
+    const component = render(<PillWrapper statuses={[]} />);
+    expect(renderToJson(component)).toMatchSnapshot();
   });
 
   it('renders with invalid statuses', () => {
     const statuses = [undefined, null, 'fnjdsahf'];
-    const component = shallow(<Pill statuses={statuses} />);
-    expect(shallowToJson(component)).toMatchSnapshot();
+    const component = render(<PillWrapper statuses={statuses} />);
+    expect(renderToJson(component)).toMatchSnapshot();
   });
 
   it('renders with a single status', () => {
     const statuses = ['review_by_legal'];
-    const component = shallow(<Pill statuses={statuses} />);
-    expect(shallowToJson(component)).toMatchSnapshot();
+    const component = render(<PillWrapper statuses={statuses} />);
+    expect(renderToJson(component)).toMatchSnapshot();
   });
 
   it('renders with multiple statuses', () => {
     const statuses = ['review_by_internal', 'published'];
-    const component = shallow(<Pill statuses={statuses} />);
-    expect(shallowToJson(component)).toMatchSnapshot();
+    const component = render(<PillWrapper statuses={statuses} />);
+    expect(renderToJson(component)).toMatchSnapshot();
   });
 });

--- a/src/components/Pill/__snapshots__/Pill.test.jsx.snap
+++ b/src/components/Pill/__snapshots__/Pill.test.jsx.snap
@@ -3,17 +3,15 @@
 exports[`Pill renders with a single status 1`] = `
 Array [
   <span
-    className="ml-2 badge badge-light"
-    key="In review"
+    class="ml-2 badge badge-light"
   >
     In review
   </span>,
   <span
-    className="ml-2"
-    key="[object Object]"
+    class="ml-2"
   >
     <i
-      className="fa fa-lock"
+      class="fa fa-lock"
     />
   </span>,
 ]
@@ -24,22 +22,19 @@ exports[`Pill renders with invalid statuses 1`] = `null`;
 exports[`Pill renders with multiple statuses 1`] = `
 Array [
   <span
-    className="ml-2 badge badge-light"
-    key="In review"
+    class="ml-2 badge badge-light"
   >
     In review
   </span>,
   <span
-    className="ml-2"
-    key="[object Object]"
+    class="ml-2"
   >
     <i
-      className="fa fa-lock"
+      class="fa fa-lock"
     />
   </span>,
   <span
-    className="ml-2 badge badge-success"
-    key="Published"
+    class="ml-2 badge badge-success"
   >
     Published
   </span>,

--- a/src/components/Pill/index.jsx
+++ b/src/components/Pill/index.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import messages from './messages';
+
 import {
   REVIEW_BY_LEGAL,
   REVIEW_BY_INTERNAL,
@@ -12,31 +16,33 @@ import {
 } from '../../data/constants';
 
 const Pill = ({ statuses }) => {
+  const { formatMessage } = useIntl();
+
   const pills = [];
   statuses.forEach((status) => {
     switch (status) {
       case ARCHIVED:
         pills.push({
-          text: 'Archived',
+          text: formatMessage(messages.statusArchived),
           className: 'badge badge-secondary',
         });
         break;
       case UNPUBLISHED:
         pills.push({
-          text: 'Unsubmitted',
+          text: formatMessage(messages.statusUnsubmitted),
           className: 'badge badge-warning',
         });
         break;
       case REVIEWED:
         pills.push({
-          text: 'Scheduled',
+          text: formatMessage(messages.statusScheduled),
           className: 'badge badge-primary',
         });
         break;
       case REVIEW_BY_LEGAL:
       case REVIEW_BY_INTERNAL:
         pills.push({
-          text: 'In review',
+          text: formatMessage(messages.statusInReview),
           className: 'badge badge-light',
         });
         pills.push({
@@ -45,7 +51,7 @@ const Pill = ({ statuses }) => {
         break;
       case PUBLISHED:
         pills.push({
-          text: 'Published',
+          text: formatMessage(messages.statusPublished),
           className: 'badge badge-success',
         });
         break;

--- a/src/components/Pill/messages.js
+++ b/src/components/Pill/messages.js
@@ -1,0 +1,31 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  statusArchived: {
+    id: 'publisher.status.archived',
+    defaultMessage: 'Archived',
+    description: 'Label on a badge element to show status.',
+  },
+  statusUnsubmitted: {
+    id: 'publisher.status.unsubmitted',
+    defaultMessage: 'Unsubmitted',
+    description: 'Label on a badge element to show status.',
+  },
+  statusScheduled: {
+    id: 'publisher.status.Scheduled',
+    defaultMessage: 'Scheduled',
+    description: 'Label on a badge element to show status.',
+  },
+  statusInReview: {
+    id: 'publisher.status.inReview',
+    defaultMessage: 'In review',
+    description: 'Label on a badge element to show status.',
+  },
+  statusPublished: {
+    id: 'publisher.status.published',
+    defaultMessage: 'Published',
+    description: 'Label on a badge element to show status.',
+  },
+});
+
+export default messages;

--- a/src/containers/MainApp/index.jsx
+++ b/src/containers/MainApp/index.jsx
@@ -2,7 +2,7 @@ import 'core-js';
 import 'regenerator-runtime/runtime';
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import Footer from '@edx/frontend-component-footer-edx';
+import Footer from '@edx/frontend-component-footer';
 
 import '../../sass/App.scss';
 import Header from '../Header';

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,9 @@
+// Placeholder messages index to be overridden by `make pull_translations`
+
+import { messages as paragonMessages } from '@edx/paragon';
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+
+export default [
+  footerMessages,
+  paragonMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,8 +8,7 @@ import {
 } from '@edx/frontend-platform';
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
 import { ConnectedRouter } from 'connected-react-router';
-import { messages as footerMessages } from '@edx/frontend-component-footer-edx';
-import { messages as paragonMessages } from '@edx/paragon';
+import messages from './i18n';
 import './sass/App.scss';
 
 import store from './data/store';
@@ -32,9 +31,6 @@ subscribe(APP_INIT_ERROR, (error) => {
 });
 
 initialize({
-  messages: [
-    footerMessages,
-    paragonMessages,
-  ],
+  messages,
   requireAuthenticatedUser: true,
 });

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -2,7 +2,7 @@
 @import "~@edx/brand/paragon/variables";
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/brand/paragon/overrides";
-@import "~@edx/frontend-component-footer-edx/dist/footer";
+@import "~@edx/frontend-component-footer/dist/footer";
 @import "./dark-mode";
 
 // Components

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -36,5 +36,5 @@ window['__react-beautiful-dnd-disable-dev-warnings'] = true;
 
 // Upgrading to Node16 shows unhandledPromiseRejection warnings as errors so adding a handler
 process.on('unhandledRejection', (reason, p) => {
-  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason.stack);
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason.stack); // eslint-disable-line no-console
 });


### PR DESCRIPTION
feat: use `atlas` in `make pull_translations`

Changes
-------
 - Bump frontend-platform to bring `intl-imports.js` script
 - Move all i18n imports into `src/i18n/index.js` so `intl-imports.js` can override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.


Testing
-------
 - [x] Fix tests and lint rules
 - [x] Test pulled translations
 - [x] Quick QA for translated content: <details><summary>Screenshot</summary><kbd>![image](https://github.com/openedx/frontend-app-publisher/assets/645156/c345b1d3-b2b4-4257-91d0-068da1604746)</kbd></details> 



References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/


