### PR TITLE
feat: add directionality plugin to the tinyMCE

### DIFF
--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -27,9 +27,10 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "#rich-text-editor-test",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue={null}
@@ -74,9 +75,10 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "#rich-text-editor-test",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"
@@ -119,9 +121,10 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "#rich-text-editor-test",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue={null}
@@ -166,9 +169,10 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
           "entity_encoding": "raw",
           "extended_valid_elements": "span[lang|id] -span",
           "menubar": false,
-          "plugins": "legacyoutput link lists language",
+          "plugins": "legacyoutput link lists language directionality",
+          "selector": "#rich-text-editor-test",
           "statusbar": false,
-          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language",
+          "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
       initialValue="<p>Prior text<p>"

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -8,6 +8,7 @@ import 'tinymce/icons/default';
 import 'tinymce/plugins/legacyoutput';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
+import 'tinymce/plugins/directionality';
 import 'tinymce/themes/silver/theme';
 import '@edx/tinymce-language-selector';
 import 'tinymce/skins/ui/oxide/skin.css';
@@ -88,9 +89,10 @@ class RichEditor extends React.Component {
             init={{
               branding: false,
               menubar: false,
-              plugins: 'legacyoutput link lists language',
+              plugins: 'legacyoutput link lists language directionality',
               statusbar: false,
-              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language',
+              selector: `#${id}`,
+              toolbar: 'undo redo | bold italic underline | bullist numlist | link | language | ltr rtl',
               entity_encoding: 'raw',
               extended_valid_elements: 'span[lang|id] -span',
               content_css: false,


### PR DESCRIPTION
[PROD-3220] (https://2u-internal.atlassian.net/browse/PROD-3220)
This PR add the directionality plugin to tinyMCE editor and add the directionality button to the toolbar of the editor to allow the user to change the direction of the text (RTL or LTR). 
I've already whitelisted dir attribute for paragraphs in the PR: https://github.com/openedx/course-discovery/pull/3908

### Demo Video:

https://github.com/openedx/frontend-app-publisher/assets/78806673/1f793a60-c244-42ae-a16e-cb36030715ed

