### PR TITLE
fix: regex pattern for slug pattern

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -282,7 +282,7 @@ describe('BaseEditCourseForm', () => {
     urlSlugField.prop('extraInput').onInvalid({ target: { setCustomValidity: setCustomValidityMock } });
     urlSlugField.simulate('input', { target: { value: invalidInput } });
     expect(setCustomValidityMock).toHaveBeenCalledWith(
-      'Please enter a valid URL slug. Course URL slug contains only lowercase letters, numbers, underscores, and dashes only.',
+      'Please enter a valid URL slug. Course URL slug contains lowercase letters, numbers, underscores, and dashes only.',
     );
 
     // check that it will clear onInput after invalid input

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -153,7 +153,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>
@@ -1966,7 +1966,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>
@@ -3817,7 +3817,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>
@@ -5974,7 +5974,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>
@@ -7825,7 +7825,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>
@@ -9183,7 +9183,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
         }
         name="url_slug"
         optional={true}
-        pattern="^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$"
+        pattern="^[a-z0-9_]+(?:-[a-z0-9_]+)*$"
         type="text"
       />
       <div>

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -22,13 +22,14 @@ const NORMALIZE_DATE_MATCHER = /20\d{2}\/(0\d{1}|1[0-2])\/([0-2]\d{1}|3[0-1])/;
 
 const EXECUTIVE_EDUCATION_SLUG = 'executive-education-2u';
 
-const COURSE_URL_SLUG_PATTERN_OLD = '^[a-z0-9-_]+(?:-[a-z0-9-_]+)*$';
-const COURSE_URL_SLUG_PATTERN_NEW = '^learn/[a-zA-z0-9-_]+/[a-zA-z0-9-_]+$';
-const COURSE_URL_SLUG_PATTERN = `${COURSE_URL_SLUG_PATTERN_OLD}|${COURSE_URL_SLUG_PATTERN_NEW}`;
+const COURSE_URL_SLUG_PATTERN_OLD = '^[a-z0-9_]+(?:-[a-z0-9_]+)*$';
+const COURSE_URL_SLUG_PATTERN_NEW = '^learn/[a-z0-9_]+(?:-?[a-z0-9_]+)*/[a-z0-9_]+(?:-?[a-z0-9_]+)*$';
+const COURSE_URL_SLUG_PATTERN = `${COURSE_URL_SLUG_PATTERN_NEW}|${COURSE_URL_SLUG_PATTERN_OLD}`;
 
 const COURSE_URL_SLUG_VALIDATION_MESSAGE = {
-  [COURSE_URL_SLUG_PATTERN_OLD]: 'Course URL slug contains only lowercase letters, numbers, underscores, and dashes only.',
-  [COURSE_URL_SLUG_PATTERN]: 'Course URL slug contains only lowercase letters, numbers, underscores, and dashes only and must in the format learn/<primary_subject>/<org-slug>-<course_slug> or learn/<some-custom-slug>.',
+  [COURSE_URL_SLUG_PATTERN_OLD]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only.',
+  [COURSE_URL_SLUG_PATTERN_NEW]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must in the format learn/<primary_subject>/<org-slug>-<course_slug>',
+  [COURSE_URL_SLUG_PATTERN]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must in the format learn/<primary_subject>/<org-slug>-<course_slug> or learn/<some-custom-slug>.',
 };
 
 export {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import history from '../data/history';
 import {
   COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, COURSE_URL_SLUG_PATTERN,
-  COURSE_URL_SLUG_PATTERN_OLD, MASTERS_TRACK, POST_REVIEW_STATUSES, IN_REVIEW_STATUS,
+  COURSE_URL_SLUG_PATTERN_OLD, MASTERS_TRACK, POST_REVIEW_STATUSES, IN_REVIEW_STATUS, COURSE_URL_SLUG_PATTERN_NEW,
 } from '../data/constants';
 import DiscoveryDataApiService from '../data/services/DiscoveryDataApiService';
 import { PAGE_SIZE } from '../data/constants/table';
@@ -39,9 +39,10 @@ const getCourseUrlSlugPattern = (updatedSlugFlag, courseRunStatuses, productSour
   if (updatedSlugFlag && productSource === DEFAULT_PRODUCT_SOURCE && courseRunStatuses.some((status) =>
     // eslint-disable-next-line implicit-arrow-linebreak
     (IN_REVIEW_STATUS.includes(status) || POST_REVIEW_STATUSES.includes(status)))) {
-    return COURSE_URL_SLUG_PATTERN;
+    return COURSE_URL_SLUG_PATTERN_NEW;
   }
-  return updatedSlugFlag ? '' : COURSE_URL_SLUG_PATTERN_OLD;
+  // eslint-disable-next-line max-len
+  return updatedSlugFlag && productSource === DEFAULT_PRODUCT_SOURCE ? COURSE_URL_SLUG_PATTERN : COURSE_URL_SLUG_PATTERN_OLD;
 };
 
 const updateUrl = (queryOptions) => {

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,5 +1,5 @@
 import * as utils from '.';
-import { COURSE_URL_SLUG_PATTERN, COURSE_URL_SLUG_PATTERN_OLD } from '../data/constants';
+import { COURSE_URL_SLUG_PATTERN, COURSE_URL_SLUG_PATTERN_NEW, COURSE_URL_SLUG_PATTERN_OLD } from '../data/constants';
 import { DEFAULT_PRODUCT_SOURCE } from '../data/constants/productSourceOptions';
 
 const initialRuns = [
@@ -64,7 +64,7 @@ describe('getCourseUrlSlugPattern', () => {
       const courseRunStatuses = ['review_by_legal', 'review_by_internal'];
       expect(
         utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE),
-      ).toEqual(COURSE_URL_SLUG_PATTERN);
+      ).toEqual(COURSE_URL_SLUG_PATTERN_NEW);
     },
   );
 
@@ -75,16 +75,18 @@ describe('getCourseUrlSlugPattern', () => {
       const courseRunStatuses = ['published', 'reviewed'];
       expect(
         utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE),
-      ).toEqual(COURSE_URL_SLUG_PATTERN);
+      ).toEqual(COURSE_URL_SLUG_PATTERN_NEW);
     },
   );
 
   it(
-    'returns the empty pattern when updatedSlugFlag is true and courseRunStatuses are not in review or post review',
+    'returns the both old & new pattern when updatedSlugFlag is true and courseRunStatuses are not in review or post review',
     () => {
       const updatedSlugFlag = true;
       const courseRunStatuses = ['archived'];
-      expect(utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE)).toEqual('');
+      expect(
+        utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE),
+      ).toEqual(COURSE_URL_SLUG_PATTERN);
     },
   );
 


### PR DESCRIPTION
Description
---------------
This PR fixes regex pattern for URL slug field.

### Testing Instructions:
- Enter the current url slug pattern (Alphanumeric, -, _) and check if it is working properly, Enter the invalid slugs as well to check the validity
- Update `IS_NEW_SLUG_FORMAT_ENABLED` value from `.env.development` file to true and check if it is accepting both updated & old url slug for OCM courses if none of its course in `POST REVIEW` or `IN REVIEW` state and old format slug for remaining