### PR TITLE
feat: allow both slug formats until complete rollout

### DIFF
--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -28,8 +28,8 @@ const COURSE_URL_SLUG_PATTERN = `${COURSE_URL_SLUG_PATTERN_NEW}|${COURSE_URL_SLU
 
 const COURSE_URL_SLUG_VALIDATION_MESSAGE = {
   [COURSE_URL_SLUG_PATTERN_OLD]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only.',
-  [COURSE_URL_SLUG_PATTERN_NEW]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must in the format learn/<primary_subject>/<org-slug>-<course_slug>',
-  [COURSE_URL_SLUG_PATTERN]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must in the format learn/<primary_subject>/<org-slug>-<course_slug> or learn/<some-custom-slug>.',
+  [COURSE_URL_SLUG_PATTERN_NEW]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format learn/<primary_subject>/<org-slug>-<course_slug>',
+  [COURSE_URL_SLUG_PATTERN]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must in the format <custom-url-slug> or learn/<primary_subject>/<org-slug>-<course_slug>.',
 };
 
 export {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import history from '../data/history';
 import {
   COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, COURSE_URL_SLUG_PATTERN,
-  COURSE_URL_SLUG_PATTERN_OLD, MASTERS_TRACK, POST_REVIEW_STATUSES, IN_REVIEW_STATUS, COURSE_URL_SLUG_PATTERN_NEW,
+  COURSE_URL_SLUG_PATTERN_OLD, MASTERS_TRACK, POST_REVIEW_STATUSES, IN_REVIEW_STATUS,
 } from '../data/constants';
 import DiscoveryDataApiService from '../data/services/DiscoveryDataApiService';
 import { PAGE_SIZE } from '../data/constants/table';
@@ -39,7 +39,8 @@ const getCourseUrlSlugPattern = (updatedSlugFlag, courseRunStatuses, productSour
   if (updatedSlugFlag && productSource === DEFAULT_PRODUCT_SOURCE && courseRunStatuses.some((status) =>
     // eslint-disable-next-line implicit-arrow-linebreak
     (IN_REVIEW_STATUS.includes(status) || POST_REVIEW_STATUSES.includes(status)))) {
-    return COURSE_URL_SLUG_PATTERN_NEW;
+    // change to COURSE_URL_SLUG_PATTERN_NEW when rollout is complete
+    return COURSE_URL_SLUG_PATTERN;
   }
   // eslint-disable-next-line max-len
   return updatedSlugFlag && productSource === DEFAULT_PRODUCT_SOURCE ? COURSE_URL_SLUG_PATTERN : COURSE_URL_SLUG_PATTERN_OLD;

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,5 +1,5 @@
 import * as utils from '.';
-import { COURSE_URL_SLUG_PATTERN, COURSE_URL_SLUG_PATTERN_NEW, COURSE_URL_SLUG_PATTERN_OLD } from '../data/constants';
+import { COURSE_URL_SLUG_PATTERN, COURSE_URL_SLUG_PATTERN_OLD } from '../data/constants';
 import { DEFAULT_PRODUCT_SOURCE } from '../data/constants/productSourceOptions';
 
 const initialRuns = [
@@ -64,7 +64,7 @@ describe('getCourseUrlSlugPattern', () => {
       const courseRunStatuses = ['review_by_legal', 'review_by_internal'];
       expect(
         utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE),
-      ).toEqual(COURSE_URL_SLUG_PATTERN_NEW);
+      ).toEqual(COURSE_URL_SLUG_PATTERN);
     },
   );
 
@@ -75,7 +75,7 @@ describe('getCourseUrlSlugPattern', () => {
       const courseRunStatuses = ['published', 'reviewed'];
       expect(
         utils.getCourseUrlSlugPattern(updatedSlugFlag, courseRunStatuses, DEFAULT_PRODUCT_SOURCE),
-      ).toEqual(COURSE_URL_SLUG_PATTERN_NEW);
+      ).toEqual(COURSE_URL_SLUG_PATTERN);
     },
   );
 


### PR DESCRIPTION
[PROD-3449](https://2u-internal.atlassian.net/browse/PROD-3449)
------------------
This PR temporarily allows normal slug format even if `learn` slug format is enabled

### Testing Instructions:
- Enter the current url slug pattern (Alphanumeric, -, _) and check if it is working properly. Enter invalid slugs and check appropriate message is displayed.
- Update `IS_NEW_SLUG_FORMAT_ENABLED` value from `.env.development` file to true and check if it is accepting both updated & old url slug for OCM courses and only old url format for other courses.  **Check that behavior for OCM courses is same in case of both published and unpublished courses**

### Note: 
You may get validation errors on the backend with `learn` format slugs. You can either ignore them or comment out [this line in discovery](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/api/v1/views/courses.py#L390)
