### PR TITLE
fix: skip nonExempt changes check for newly created runs that do not appear in form

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -158,6 +158,12 @@ const isNonExemptChanged = (initialValues, currentFormValues, runKey) => {
     const { course_runs: currentRuns } = currentFormValues;
     if (currentRuns) {
       const index = currentRuns.findIndex(run => run.key === runKey);
+      // When a new run is created, the form does not contain the new run form immediately.
+      // The new run form is accessible only when the form renders after creation of course run
+      // or when the course page is reloaded.
+      if (index === -1) {
+        return false;
+      }
       return COURSE_RUN_NON_EXEMPT_FIELDS.some(field => (
         initialRuns[index][field] !== currentRuns[index][field]
       ));

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -161,6 +161,18 @@ describe('isNonExemptChanged', () => {
   it('returns false when no non exempt course run fields are changed', () => {
     expect(utils.isNonExemptChanged(initialValues, currentValues, 'key-1')).toEqual(false);
   });
+
+  it('returns false when the course run key is not present in the current form values', () => {
+    const newInitialValues = {
+      title: initialValues.title,
+      course_runs: [...initialRuns, {
+        key: 'key-3',
+        expected_program_name: 'program-name',
+        expected_program_type: 'program-type',
+      }],
+    };
+    expect(utils.isNonExemptChanged(newInitialValues, currentValues, 'key-3')).toEqual(false);
+  });
 });
 
 describe('isPristine', () => {


### PR DESCRIPTION
### [PROD-3249](https://2u-internal.atlassian.net/browse/PROD-3249)

### Description

When a new course or course run is created, the [nonEmexptField](https://github.com/openedx/frontend-app-publisher/blob/6f75320c9ee491c6875e3dbbffb9a53f9c358166/src/utils/index.js#L134) checks for course run for newly created run fail with the error "that undefined does not have `expected_program_name` field". 
 This is happening because when a new run is created, the redux form state does not update to include the new run. This line `const index = currentRuns.findIndex(run => run.key === runKey);` returns -1 because new run is not present in form fields. The -1 index then causes undefined error on the upcoming lines in the exempt checks.

To counter this, do not perform the exempt checks on the newly created run because the form is not rendered yet and technically, there are no edits in the form. 
**I tried fetching the updated data but for some reason, the form state did not update with latest run value. The form state is only updated when form is first rendered for a new run.**

### Testing

- Checkout this branch
- Open any course in publisher and create a new run. Ensure the new run is created and page does not throw any error
- Checkout to master and create a new run again. The run will create but page will throw the error. Reloading the page renders the new run.