### PR TITLE
feat: do not require staff when submitting runs

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -440,6 +440,7 @@ class CollapsibleCourseRun extends React.Component {
               </p>
             </div>
           )}
+          optional
         />
         <Field
           name={`${courseId}.staff`}

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -346,7 +346,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -960,7 +960,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -1574,7 +1574,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -2188,7 +2188,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -2814,7 +2814,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -3440,7 +3440,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field
@@ -4071,7 +4071,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
       </div>
     }
     id="test-course.staff.label"
-    optional={false}
+    optional={true}
     text="Staff"
   />
   <Field

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -111,7 +111,7 @@ const handleCourseEditFail = (errors) => {
 };
 
 const editCourseValidate = (values, props) => {
-  const { targetRun, registeredFields } = props;
+  const { targetRun } = props;
 
   if (!targetRun || targetRun.status === PUBLISHED) {
     return {};
@@ -156,17 +156,7 @@ const editCourseValidate = (values, props) => {
     const { key: targetKey } = targetRun;
     const isSubmittingRun = run.key === targetKey;
     if (isSubmittingRun) {
-      // naive check to deteremine if track is executive education or not
-      const isExecutiveEducation = registeredFields
-        && registeredFields['prices.paid-executive-education']
-        && registeredFields['prices.paid-executive-education'].count;
-
-      // naive check to deteremine if track is bootcamp or not
-      const isBootcamp = registeredFields
-        && registeredFields['prices.paid-bootcamp']
-        && registeredFields['prices.paid-bootcamp'].count;
-
-      const runRequiredFields = (isExecutiveEducation || isBootcamp) ? ['transcript_languages'] : ['transcript_languages', 'staff'];
+      const runRequiredFields = ['transcript_languages'];
       const runErrors = {};
       runRequiredFields.forEach((fieldName) => {
         const value = run[fieldName];

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -187,7 +187,7 @@ describe('editCourseValidate', () => {
     expect(editCourseValidate(values, { targetRun: unpublishedTargetRun })).toEqual(expectedErrors);
   });
 
-  it('returns errors on submitting course runs with missing staff', () => {
+  it('does not return error when submitting course runs with missing staff', () => {
     const values = {
       short_description: 'Short',
       full_description: 'Full',
@@ -209,75 +209,7 @@ describe('editCourseValidate', () => {
       ],
     };
 
-    const expectedErrors = {
-      course_runs: [
-        null,
-        {
-          staff: requiredMessage,
-        },
-      ],
-    };
-    expect(editCourseValidate(values, { targetRun: unpublishedTargetRun })).toEqual(expectedErrors);
-  });
-  it('returns no error on submitting 2U executive education course runs with missing staff', () => {
-    const values = {
-      short_description: 'Short',
-      full_description: 'Full',
-      outcome: 'Outcome',
-      imageSrc: 'base64;encodedimage',
-      course_runs: [
-        {
-          key: 'NonSubmittingTestRun',
-        },
-        {
-          key: 'TestRun',
-          transcript_languages: [
-            {
-              dummy_field: 'Transcript languages dummy field',
-            },
-          ],
-          staff: [],
-        },
-      ],
-    };
-    expect(editCourseValidate(values, {
-      targetRun: unpublishedTargetRun,
-      registeredFields: {
-        'prices.paid-executive-education': {
-          count: 1,
-        },
-      },
-    })).toEqual({});
-  });
-  it('returns no error on submitting 2U bootcamp runs with missing staff', () => {
-    const values = {
-      short_description: 'Short',
-      full_description: 'Full',
-      outcome: 'Outcome',
-      imageSrc: 'base64;encodedimage',
-      course_runs: [
-        {
-          key: 'NonSubmittingTestRun',
-        },
-        {
-          key: 'TestRun',
-          transcript_languages: [
-            {
-              dummy_field: 'Transcript languages dummy field',
-            },
-          ],
-          staff: [],
-        },
-      ],
-    };
-    expect(editCourseValidate(values, {
-      targetRun: unpublishedTargetRun,
-      registeredFields: {
-        'prices.paid-bootcamp': {
-          count: 1,
-        },
-      },
-    })).toEqual({});
+    expect(editCourseValidate(values, { targetRun: unpublishedTargetRun })).toEqual({});
   });
 
   test.each([


### PR DESCRIPTION
### [PROD-3587](https://2u-internal.atlassian.net/browse/PROD-3587)

### Description
Do not require staff when submitting course runs. This is applicable for both OCs & non-OCs (ExecEd & Bootcamps)

### Testing
- Open any course on publisher
- Create a new run for the course. Add required information but dont add Staff information. Notice the staff field will now mention that staff is optional.
- Submit run for review. The run will be submitted for review.
- Complete the review cycle for course run. No staff related error will be raised.