### PR TITLE
chore: add subdirectory slug format for bootcamps

### DIFF
--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -21,6 +21,7 @@ const FORMAT_DATE_MATCHER = /20\d{2}-(0\d{1}|1[0-2])-([0-2]\d{1}|3[0-1])/;
 const NORMALIZE_DATE_MATCHER = /20\d{2}\/(0\d{1}|1[0-2])\/([0-2]\d{1}|3[0-1])/;
 
 const EXECUTIVE_EDUCATION_SLUG = 'executive-education-2u';
+const BOOTCAMP_SLUG = 'bootcamp-2u';
 
 const COURSE_URL_SLUG_PATTERN_OLD = '^[a-z0-9_]+(?:-[a-z0-9_]+)*$';
 const COURSE_URL_SLUG_PATTERN_NEW = '^learn/[a-z0-9_]+(?:-?[a-z0-9_]+)*/[a-z0-9_]+(?:-?[a-z0-9_]+)*$';
@@ -53,6 +54,7 @@ export {
   COURSE_EXEMPT_FIELDS,
   COURSE_RUN_NON_EXEMPT_FIELDS,
   EXECUTIVE_EDUCATION_SLUG,
+  BOOTCAMP_SLUG,
   COURSE_URL_SLUG_PATTERN,
   COURSE_URL_SLUG_PATTERN_NEW,
   COURSE_URL_SLUG_PATTERN_OLD,

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -17,6 +17,10 @@ process.env.COURSE_URL_SLUGS_PATTERN = `{
         "default": {
             "slug_format": "^learn/[a-z0-9_]+(?:-?[a-z0-9_]+)*/[a-z0-9_]+(?:-?[a-z0-9_]+)*$|^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
             "error_msg": "Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format <custom-url-slug> or learn/<primary_subject>/<org-slug>-<course_slug>."
+        },
+        "bootcamp-2u": {
+            "slug_format": "^boot-camps/[a-z0-9_]+(?:-?[a-z0-9_]+)*/[a-z0-9_]+(?:-?[a-z0-9_]+)*$|^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+            "error_msg": "Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format <custom-url-slug> or boot-camps/<primary_subject>/<org-slug>-<course_slug>."
         }
     },
     "external-source": {
@@ -27,6 +31,10 @@ process.env.COURSE_URL_SLUGS_PATTERN = `{
         "executive-education-2u": {
             "slug_format": "^executive-education/[a-z0-9_]+(?:-?[a-z0-9_]+)*$|^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
             "error_msg": "Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format <custom-url-slug> or executive-education/<org-slug>-<course_slug>."
+        },
+        "bootcamp-2u": {
+            "slug_format": "^boot-camps/[a-z0-9_]+(?:-?[a-z0-9_]+)*/[a-z0-9_]+(?:-?[a-z0-9_]+)*$|^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+            "error_msg": "Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format <custom-url-slug> or boot-camps/<primary_subject>/<org-slug>-<course_slug>."
         }
     }
 }`;

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,5 +1,5 @@
 import * as utils from '.';
-import { COURSE_URL_SLUG_PATTERN_OLD, EXECUTIVE_EDUCATION_SLUG } from '../data/constants';
+import { BOOTCAMP_SLUG, COURSE_URL_SLUG_PATTERN_OLD, EXECUTIVE_EDUCATION_SLUG } from '../data/constants';
 import { DEFAULT_PRODUCT_SOURCE } from '../data/constants/productSourceOptions';
 
 const initialRuns = [
@@ -127,6 +127,27 @@ describe('getCourseUrlSlugPattern', () => {
         slug_format: COURSE_URL_SLUG_PATTERN_OLD,
         error_msg: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only.',
       });
+    },
+  );
+
+  it(
+    'returns the old course url slug pattern when courseType is bootcamp and updatedSlugFlag is false',
+    () => {
+      expect(
+        utils.getCourseUrlSlugPattern(false, 'external-source', BOOTCAMP_SLUG),
+      ).toEqual({
+        slug_format: COURSE_URL_SLUG_PATTERN_OLD,
+        error_msg: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only.',
+      });
+    },
+  );
+
+  it(
+    'returns the bootcamp subdirectory slug pattern when courseType is bootcamp and updatedSlugFlag is true',
+    () => {
+      expect(
+        utils.getCourseUrlSlugPattern(true, 'external-source', BOOTCAMP_SLUG),
+      ).toEqual(JSON.parse(COURSE_URL_SLUGS_PATTERN)['external-source'][BOOTCAMP_SLUG]);
     },
   );
 });


### PR DESCRIPTION
[PROD-3592](https://2u-internal.atlassian.net/browse/PROD-3592)
------------

<img width="981" alt="image" src="https://github.com/openedx/frontend-app-publisher/assets/78806673/b666e602-2099-4ab5-a54d-a60e649d9cd3">


This PR adds the test in publisher to verify the URL slug format for bootcamps.