### PR TITLE
fix: include reviewed to allowed statuses

### DIFF
--- a/src/components/SidePanes/CatalogInclusionPane.jsx
+++ b/src/components/SidePanes/CatalogInclusionPane.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Form, Spinner } from '@edx/paragon';
-import { PUBLISHED, UNPUBLISHED } from '../../data/constants';
+import { PUBLISHED, REVIEWED, UNPUBLISHED } from '../../data/constants';
 
 import DiscoveryDataApiService from '../../data/services/DiscoveryDataApiService';
 import Pane from './Pane';
@@ -24,7 +24,7 @@ const CatalogInclusionPane = ({
     e.preventDefault();
     setIsLoading(true);
     let draft = null;
-    if (draftStatuses.includes(PUBLISHED)) {
+    if (draftStatuses.includes(PUBLISHED) || draftStatuses.includes(REVIEWED)) {
       draft = false;
     } else if (draftStatuses.includes(UNPUBLISHED)) {
       draft = true;
@@ -47,7 +47,7 @@ const CatalogInclusionPane = ({
         setError(null);
         setIsLoading(false);
       } catch (err) {
-        const errorText = `Unable to toggle attribute, recieved error: ${err.response.status} ${err.response.statusText}`;
+        const errorText = `Unable to toggle attribute, received error: ${err.response.status} ${err.response.statusText}`;
         setIsLoading(false);
         setError(errorText);
       }

--- a/src/components/SidePanes/CatalogInclusionPane.test.jsx
+++ b/src/components/SidePanes/CatalogInclusionPane.test.jsx
@@ -2,46 +2,61 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import CatalogInclusionPane from './CatalogInclusionPane';
+import DiscoveryDataApiService from '../../data/services/DiscoveryDataApiService';
 
 describe('CatalogInclusionPane', () => {
   const mockUuid = 'test-enterprise-id';
-  const mockInclusion = false;
+  const mockSubInclusion = false;
+  const mockOrgInclusion = true;
+  const spy = jest.spyOn(DiscoveryDataApiService, 'editCourse');
 
   it('correct toggle behavior', () => {
     const wrapper = mount(<CatalogInclusionPane
       courseUuid={mockUuid}
-      subInclusion={mockInclusion}
+      subInclusion={mockSubInclusion}
       draftStatuses={['published']}
-      orgInclusion
+      orgInclusion={mockOrgInclusion}
     />);
     wrapper.find(CatalogInclusionPane);
     const title = wrapper.find('Enterprise Subscriptions');
     expect(title);
     const toggle = wrapper.find('.pgn__form-switch-input');
     toggle.simulate('change', { target: { checked: false } });
-    expect(toggle.props().checked).toBe(false);
+    expect(spy).toBeCalledWith(
+      {
+        draft: false,
+        enterprise_subscription_inclusion: !mockSubInclusion,
+        uuid: 'test-enterprise-id',
+      },
+    );
   });
 
   it('allow course runs who have been reviewed', () => {
     const wrapper = mount(<CatalogInclusionPane
       courseUuid={mockUuid}
-      subInclusion={mockInclusion}
+      subInclusion={mockSubInclusion}
       draftStatuses={['reviewed']}
-      orgInclusion
+      orgInclusion={mockOrgInclusion}
     />);
     wrapper.find(CatalogInclusionPane);
     const title = wrapper.find('Enterprise Subscriptions');
     expect(title);
     const toggle = wrapper.find('.pgn__form-switch-input');
     toggle.simulate('change', { target: { checked: false } });
-    expect(toggle.props().checked).toBe(false);
+    expect(spy).toBeCalledWith(
+      {
+        draft: false,
+        enterprise_subscription_inclusion: !mockSubInclusion,
+        uuid: 'test-enterprise-id',
+      },
+    );
   });
-
   it('toggle disabled when org is false', () => {
     const wrapper = mount(<CatalogInclusionPane
       courseUuid={mockUuid}
-      subInclusion={mockInclusion}
+      subInclusion={mockSubInclusion}
       draftStatuses={['published']}
+      orgInclusion={false}
     />);
     // org not included helper text
     expect(wrapper.find('.text-gray-300')).toHaveLength(1);
@@ -49,9 +64,9 @@ describe('CatalogInclusionPane', () => {
   it('toggle blocked in review status', () => {
     const wrapper = mount(<CatalogInclusionPane
       courseUuid={mockUuid}
-      subInclusion={mockInclusion}
+      subInclusion={mockSubInclusion}
       draftStatuses={['review_by_internal']}
-      orgInclusion
+      orgInclusion={mockOrgInclusion}
     />);
     const toggle = wrapper.find('.pgn__form-switch-input');
     toggle.simulate('change', { target: { checked: false } });

--- a/src/components/SidePanes/CatalogInclusionPane.test.jsx
+++ b/src/components/SidePanes/CatalogInclusionPane.test.jsx
@@ -22,6 +22,21 @@ describe('CatalogInclusionPane', () => {
     expect(toggle.props().checked).toBe(false);
   });
 
+  it('allow course runs who have been reviewed', () => {
+    const wrapper = mount(<CatalogInclusionPane
+      courseUuid={mockUuid}
+      subInclusion={mockInclusion}
+      draftStatuses={['reviewed']}
+      orgInclusion
+    />);
+    wrapper.find(CatalogInclusionPane);
+    const title = wrapper.find('Enterprise Subscriptions');
+    expect(title);
+    const toggle = wrapper.find('.pgn__form-switch-input');
+    toggle.simulate('change', { target: { checked: false } });
+    expect(toggle.props().checked).toBe(false);
+  });
+
   it('toggle disabled when org is false', () => {
     const wrapper = mount(<CatalogInclusionPane
       courseUuid={mockUuid}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8076

Previously, we only allowed you to toggle the enterprise subscription inclusion if your course run was published, but now we are also allowing it if it is reviewed and scheduled. In response to a bug filed by a Harvard customer. 