### PR TITLE
fetch restricted runs in publisher

### DIFF
--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -39,7 +39,7 @@ const RESTRICTION_TYPE_OPTIONS = [
   { value: 'custom-b2c', label: 'Custom B2C' },
 ];
 
-const RESTRICTION_TYPE_VALUES = RESTRICTION_TYPE_OPTIONS.map(opt=>opt.value).filter(Boolean).join(',')
+const RESTRICTION_TYPE_VALUES = RESTRICTION_TYPE_OPTIONS.map(opt => opt.value).filter(Boolean).join(',');
 
 export {
   VERIFIED_TRACK,

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -33,6 +33,14 @@ const COURSE_URL_SLUG_VALIDATION_MESSAGE = {
   [COURSE_URL_SLUG_PATTERN]: 'Course URL slug contains lowercase letters, numbers, underscores, and dashes only and must be in the format <custom-url-slug> or learn/<primary_subject>/<org-slug>-<course_slug>.',
 };
 
+const RESTRICTION_TYPE_OPTIONS = [
+  { value: '', label: '--------' },
+  { value: 'custom-b2b-enterprise', label: 'Custom Enterprise' },
+  { value: 'custom-b2c', label: 'Custom B2C' },
+];
+
+const RESTRICTION_TYPE_VALUES = RESTRICTION_TYPE_OPTIONS.map(opt=>opt.value).filter(Boolean).join(',')
+
 export {
   VERIFIED_TRACK,
   AUDIT_TRACK,
@@ -59,4 +67,6 @@ export {
   COURSE_URL_SLUG_PATTERN_NEW,
   COURSE_URL_SLUG_PATTERN_OLD,
   COURSE_URL_SLUG_VALIDATION_MESSAGE,
+  RESTRICTION_TYPE_OPTIONS,
+  RESTRICTION_TYPE_VALUES,
 };

--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -1,6 +1,7 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { PAGE_SIZE } from '../constants/table';
+import { RESTRICTION_TYPE_VALUES as restrictionTypeValues } from '../constants';
 
 const discoveryBaseUrl = `${process.env.DISCOVERY_API_BASE_URL}/api/v1`;
 const publisherBaseUrl = `${process.env.DISCOVERY_API_BASE_URL}/publisher/api`;
@@ -10,6 +11,7 @@ class DiscoveryDataApiService {
     const queryParams = {
       editable: 1,
       exclude_utm: 1,
+      include_restricted: restrictionTypeValues,
     };
     const url = `${discoveryBaseUrl}/courses/${uuid}/`;
     return getAuthenticatedHttpClient().get(url, {
@@ -21,6 +23,7 @@ class DiscoveryDataApiService {
     const queryParams = {
       editable: 1,
       exclude_utm: 1,
+      include_restricted: restrictionTypeValues,
       ...params,
     };
     const url = `${discoveryBaseUrl}/course_runs/${key}`;
@@ -45,6 +48,7 @@ class DiscoveryDataApiService {
       fields: fields.join(),
       editable: 1,
       exclude_utm: 1,
+      include_restricted: restrictionTypeValues,
       ...options,
     };
     const url = `${discoveryBaseUrl}/courses/`;
@@ -145,6 +149,7 @@ class DiscoveryDataApiService {
   static editCourseRuns(courseRunsData) {
     const queryParams = {
       exclude_utm: 1,
+      include_restricted: restrictionTypeValues,
     };
     // Create a promises array to handle all of the new/modified course runs
     const promises = courseRunsData.map((courseRun) => {
@@ -213,6 +218,7 @@ class DiscoveryDataApiService {
     const { uuid } = courseData;
     const queryParams = {
       exclude_utm: 1,
+      include_restricted: restrictionTypeValues,
     };
     const url = `${discoveryBaseUrl}/courses/${uuid}/`;
     return getAuthenticatedHttpClient().patch(url, courseData, {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -370,7 +370,6 @@ const buildInitialPrices = (entitlements, courseRuns) => {
 const hasMastersTrack = (runTypeUuid, runTypeModes) => (!!runTypeUuid
   && !!runTypeModes[runTypeUuid] && runTypeModes[runTypeUuid].includes(MASTERS_TRACK.key));
 
-
 export {
   courseRunIsArchived,
   getDateWithDashes,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ import qs from 'query-string';
 import {
   COURSE_EXEMPT_FIELDS, COURSE_RUN_NON_EXEMPT_FIELDS, COURSE_URL_SLUG_PATTERN_OLD,
   MASTERS_TRACK, COURSE_URL_SLUG_VALIDATION_MESSAGE, EXECUTIVE_EDUCATION_SLUG, BOOTCAMP_SLUG,
+  RESTRICTION_TYPE_OPTIONS as restrictionTypeOptions,
 } from '../data/constants';
 import DiscoveryDataApiService from '../data/services/DiscoveryDataApiService';
 import { PAGE_SIZE } from '../data/constants/table';
@@ -369,11 +370,6 @@ const buildInitialPrices = (entitlements, courseRuns) => {
 const hasMastersTrack = (runTypeUuid, runTypeModes) => (!!runTypeUuid
   && !!runTypeModes[runTypeUuid] && runTypeModes[runTypeUuid].includes(MASTERS_TRACK.key));
 
-const restrictionTypeOptions = [
-  { value: '', label: '--------' },
-  { value: 'custom-b2b-enterprise', label: 'Custom Enterprise' },
-  { value: 'custom-b2c', label: 'Custom B2C' },
-];
 
 export {
   courseRunIsArchived,


### PR DESCRIPTION
[PROD-4088](https://2u-internal.atlassian.net/browse/PROD-4088)
-------
This PR adds adds the restriction params to the API calls in Publisher to ensure that restricted runs are always fetched/updated properly in Publisher.


## Testing

1. Check out this branch
2. Open/Create an executive education course in publisher
3. Add a restriction type. Then change it. Finally remove it. 
4. Verify that the behavior is as expected.