### PR TITLE
chore: remove unhandledPromiseRejection Error in Frontend-app-publisher

### DIFF
--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -60,14 +60,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -75,30 +68,13 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -752,14 +728,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -767,30 +736,13 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -1444,14 +1396,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -1459,30 +1404,13 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -2136,14 +2064,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -2151,30 +2072,13 @@ exports[`Collapsible Course Run renders correctly when given a published course 
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -2752,14 +2656,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -2767,30 +2664,13 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -3368,14 +3248,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -3383,30 +3256,13 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -3984,14 +3840,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -3999,30 +3848,13 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -4600,14 +4432,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -4615,30 +4440,13 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -5228,14 +5036,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
               text="edX101+DemoX"
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -5243,30 +5044,13 @@ exports[`Collapsible Course Run renders correctly with external key field enable
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>
@@ -5880,14 +5664,7 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
               onCopy={[Function]}
             >
               <FontAwesomeIcon
-                beat={false}
-                beatFade={false}
-                border={false}
-                bounce={false}
                 className="text-primary ml-2"
-                fade={false}
-                fixedWidth={false}
-                flip={false}
                 icon={
                   {
                     "icon": [
@@ -5895,30 +5672,13 @@ exports[`Collapsible Course Run renders correctly with no fields 1`] = `
                       512,
                       [],
                       "f0c5",
-                      "M384 336H192c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16l140.1 0L400 115.9V320c0 8.8-7.2 16-16 16zM192 384H384c35.3 0 64-28.7 64-64V115.9c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1H192c-35.3 0-64 28.7-64 64V320c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64V448c0 35.3 28.7 64 64 64H256c35.3 0 64-28.7 64-64V416H272v32c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V192c0-8.8 7.2-16 16-16H96V128H64z",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
                     ],
                     "iconName": "copy",
                     "prefix": "far",
                   }
                 }
-                inverse={false}
-                listItem={false}
-                mask={null}
-                maskId={null}
                 onClick={[Function]}
-                pull={null}
-                pulse={false}
-                rotation={null}
-                shake={false}
-                size={null}
-                spin={false}
-                spinPulse={false}
-                spinReverse={false}
-                swapOpacity={false}
-                symbol={false}
-                title=""
-                titleId={null}
-                transform={null}
               />
             </CopyToClipboard>
           </OverlayTrigger>

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -60,8 +60,3 @@ Object.defineProperty(window, 'matchMedia', {
 // Disable all react-beautiful-dnd development warnings.
 // See https://github.com/atlassian/react-beautiful-dnd/issues/1593
 window['__react-beautiful-dnd-disable-dev-warnings'] = true;
-
-// Upgrading to Node16 shows unhandledPromiseRejection warnings as errors so adding a handler
-process.on('unhandledRejection', (reason, p) => {
-  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason.stack); // eslint-disable-line no-console
-});


### PR DESCRIPTION
[PROD-3142](https://2u-internal.atlassian.net/browse/PROD-3142)
--------
This PR removes the workaround for ignoring unhandledPromiseRejection warnings. Previously, unhandledPromiseRejection warnings were converted to errors in Node.js 15, when we run tests on Node.js 16 so this workaround added at that time.