### PR TITLE
fix: tinyMCELanguageSelectorPlugin error related to Button ID

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { debounce } from 'lodash';
 
 import { Field, FieldArray } from 'redux-form';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -281,7 +281,7 @@ class CollapsibleCourseRun extends React.Component {
 
     if (courseInReview !== isCourseRunInReview) {
         setTimeout(() => {
-            this.setState({ isCourseRunInReview: courseInReview });
+            this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
         }, 500);
     }
 

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
 
 import { Field, FieldArray } from 'redux-form';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -118,6 +119,7 @@ class CollapsibleCourseRun extends React.Component {
       copied: false,
       returnFromStaffPage: false,
       hasExternalKey: undefined,
+      isCourseRunInReview: false,
     };
 
     this.openCollapsible = this.openCollapsible.bind(this);
@@ -251,7 +253,7 @@ class CollapsibleCourseRun extends React.Component {
       courseRunTypeOptions,
       courseInfo,
     } = this.props;
-    const { copied, hasExternalKey } = this.state;
+    const { copied, hasExternalKey, isCourseRunInReview } = this.state;
     const { administrator } = getAuthenticatedUser();
 
     const courseRunInReview = IN_REVIEW_STATUS.includes(courseRun.status);
@@ -277,6 +279,12 @@ class CollapsibleCourseRun extends React.Component {
       && isPristine(initialValues, currentFormValues, courseRun.key);
     const productSource = courseInfo?.data?.product_source?.slug;
     const courseType = courseInfo?.data?.course_type;
+
+    if (courseInReview !== isCourseRunInReview) {
+        setTimeout(() => {
+            this.setState({ isCourseRunInReview: courseInReview });
+        }, 500);
+    }
 
     return (
       <Collapsible
@@ -678,7 +686,7 @@ class CollapsibleCourseRun extends React.Component {
             </div>
           </div>
           )}
-        {administrator && IN_REVIEW_STATUS.includes(courseRun.status)
+        {administrator && isCourseRunInReview
           && (
           <div>
             Status: {courseRun.status === REVIEW_BY_LEGAL ? 'Legal Review' : 'PC Review'}

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -280,9 +280,9 @@ class CollapsibleCourseRun extends React.Component {
     const courseType = courseInfo?.data?.course_type;
 
     if (IN_REVIEW_STATUS.includes(courseRun.status) !== isCourseRunInReview) {
-        setTimeout(() => {
-            this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
-        }, 100);
+      setTimeout(() => {
+         this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
+      }, 100);
     }
 
     return (

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -281,7 +281,7 @@ class CollapsibleCourseRun extends React.Component {
 
     if (IN_REVIEW_STATUS.includes(courseRun.status) !== isCourseRunInReview) {
       setTimeout(() => {
-         this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
+        this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
       }, 100);
     }
 

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -279,10 +279,10 @@ class CollapsibleCourseRun extends React.Component {
     const productSource = courseInfo?.data?.product_source?.slug;
     const courseType = courseInfo?.data?.course_type;
 
-    if (courseInReview !== isCourseRunInReview) {
+    if (IN_REVIEW_STATUS.includes(courseRun.status) !== isCourseRunInReview) {
         setTimeout(() => {
             this.setState({ isCourseRunInReview: IN_REVIEW_STATUS.includes(courseRun.status) });
-        }, 500);
+        }, 100);
     }
 
     return (

--- a/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
@@ -52,6 +52,7 @@ const publishedCourseRun = {
 };
 
 const unpublishedCourseRun = { ...publishedCourseRun, status: 'unpublished' };
+const inReviewCourseRun = { ...publishedCourseRun, status: 'review_by_internal' };
 
 const currentFormValues = {
   course_runs: [publishedCourseRun, unpublishedCourseRun],
@@ -92,6 +93,18 @@ describe('Collapsible Course Run', () => {
       courseId="test-course"
       courseUuid="11111111-1111-1111-1111-111111111111"
       index={1}
+    />);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  it('renders correctly when given a course run in review', () => {
+    const component = shallow(<CollapsibleCourseRun
+      languageOptions={languageOptions}
+      pacingTypeOptions={pacingTypeOptions}
+      courseRun={inReviewCourseRun}
+      courseId="test-course"
+      courseUuid="11111111-1111-1111-1111-111111111111"
+      index={2}
     />);
     expect(shallowToJson(component)).toMatchSnapshot();
   });

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -2004,6 +2004,598 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
 </CustomCollapsible>
 `;
 
+exports[`Collapsible Course Run renders correctly when given a course run in review 1`] = `
+<CustomCollapsible
+  open={false}
+  title={
+    <div
+      className="course-run-label"
+    >
+      <span>
+        Course run starting on Jan 01, 2000 - Self Paced
+      </span>
+      <Pill
+        statuses={
+          [
+            "review_by_internal",
+          ]
+        }
+      />
+      <div
+        className="course-run-label"
+      >
+        <span>
+          Publish date is Dec 31, 1999
+        </span>
+      </div>
+      <div
+        className="course-run-studio-url"
+      >
+        <React.Fragment>
+          Studio URL - 
+          <withDeprecatedProps(Hyperlink)
+            destination="http://localhost:18010/course/edX101+DemoX"
+            isInline={true}
+            target="_blank"
+          >
+            edX101+DemoX
+          </withDeprecatedProps(Hyperlink)>
+          <OverlayTrigger
+            defaultShow={false}
+            overlay={
+              <ForwardRef
+                bsPrefix="tooltip"
+                placement="right"
+              >
+                Copy course key
+              </ForwardRef>
+            }
+            placement="top"
+            popperConfig={{}}
+            trigger={
+              [
+                "hover",
+                "focus",
+              ]
+            }
+          >
+            <CopyToClipboard
+              onCopy={[Function]}
+              text="edX101+DemoX"
+            >
+              <FontAwesomeIcon
+                className="text-primary ml-2"
+                icon={
+                  {
+                    "icon": [
+                      448,
+                      512,
+                      [],
+                      "f0c5",
+                      "M384 336l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L400 115.9 400 320c0 8.8-7.2 16-16 16zM192 384l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9L366.1 14.1c-9-9-21.2-14.1-33.9-14.1L192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-32-48 0 0 32c0 8.8-7.2 16-16 16L64 464c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l32 0 0-48-32 0z",
+                    ],
+                    "iconName": "copy",
+                    "prefix": "far",
+                  }
+                }
+                onClick={[Function]}
+              />
+            </CopyToClipboard>
+          </OverlayTrigger>
+        </React.Fragment>
+      </div>
+    </div>
+  }
+>
+  <div
+    className="mb-3"
+  >
+    <span
+      aria-hidden={true}
+      className="text-primary-500"
+    >
+       All fields are required for publication unless otherwise specified.
+    </span>
+  </div>
+  <div>
+    <Field
+      component={[Function]}
+      disabled={true}
+      extraInput={
+        {
+          "onInvalid": [Function],
+        }
+      }
+      format={[Function]}
+      label={
+        <FieldLabel
+          className=""
+          extraText=""
+          helpText={
+            <div>
+              <p>
+                Required Format: yyyy/mm/dd
+              </p>
+              <p>
+                The scheduled date for when the course run will be live and published.
+              </p>
+              <p>
+                To publish as soon as possible, set the publish date to today. Please note that changes may take 48 hours to go live.
+              </p>
+              <p>
+                If you don’t have a publish date yet, set to 1 year in the future.
+              </p>
+            </div>
+          }
+          id="test-course.go_live_date.label"
+          optional={false}
+          text="Publish date"
+        />
+      }
+      maxLength="10"
+      name="test-course.go_live_date"
+      normalize={[Function]}
+      pattern="20[1-9][0-9]/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01])"
+      placeholder="yyyy/mm/dd"
+      required={false}
+      type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Start date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.start"
+      timeLabel="Start time (GMT)"
+      type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="End date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.end"
+      timeLabel="End time (GMT)"
+      type="text"
+    />
+    <Field
+      component={[Function]}
+      dateLabel="Upgrade deadline override date"
+      disabled={true}
+      helpText={
+        <div>
+          <p>
+            Course run dates are editable in Studio.
+          </p>
+          <p>
+            Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+          </p>
+          <p>
+            <a
+              href="http://localhost:18010/settings/details/edX101+DemoX#schedule"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Edit dates.
+            </a>
+            .
+          </p>
+        </div>
+      }
+      name="test-course.upgrade_deadline_override"
+      timeLabel="Upgrade deadline override time (UTC)"
+      type="date"
+      utcTimeZone={true}
+    />
+  </div>
+  <hr />
+  <Field
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    label={
+      <FieldLabel
+        className=""
+        extraText="Cannot edit after submission"
+        helpText={
+          <div>
+            <p>
+              The enrollment track determines whether a course run offers a paid certificate and what sort of verification is required.
+            </p>
+            <p>
+              <a
+                href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/glossary.html#enrollment-track-g"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Learn more.
+              </a>
+            </p>
+          </div>
+        }
+        id="test-course.run_type.label"
+        optional={false}
+        text="Course run enrollment track"
+      />
+    }
+    name="test-course.run_type"
+    options={
+      [
+        {
+          "label": "Select Course enrollment track first",
+          "value": "",
+        },
+      ]
+    }
+    required={true}
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
+    label={
+      <FieldLabel
+        className=""
+        extraText=""
+        helpText={
+          <div>
+            <p>
+              Course pacing is editable in Studio.
+            </p>
+            <p>
+              Please note that changes in Studio may take up to a business day to be reflected here. For questions, contact your project coordinator.
+            </p>
+            <p>
+              <a
+                href="http://localhost:18010/settings/details/edX101+DemoX"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Edit course pacing.
+              </a>
+              .
+            </p>
+          </div>
+        }
+        id="test-course.pacing_type.label"
+        optional={false}
+        text="Course pacing"
+      />
+    }
+    name="test-course.pacing_type"
+    options={
+      [
+        {
+          "label": "Self-paced",
+          "value": "self_paced",
+        },
+      ]
+    }
+    type="text"
+  />
+  <FieldLabel
+    className="mb-2"
+    extraText=""
+    helpText={
+      <div>
+        <p>
+          The primary instructor or instructors for the course.
+        </p>
+        <p>
+          The order that instructors are listed here is the same order they will be displayed on course pages. You can drag and drop to reorder instructors.
+        </p>
+      </div>
+    }
+    id="test-course.staff.label"
+    optional={true}
+    text="Staff"
+  />
+  <Field
+    component={[Function]}
+    courseRunKey="edX101+DemoX"
+    createNewUrl="/instructors/new"
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    fetchSuggestions={[Function]}
+    itemType="staff"
+    name="test-course.staff"
+    newItemInfo={{}}
+    newItemText="Add New Instructor"
+    owners={[]}
+    referrer="/courses/11111111-1111-1111-1111-111111111111"
+    renderItemComponent={[Function]}
+    renderSuggestion={[Function]}
+    sourceInfo={{}}
+  />
+  <div
+    className="row"
+  >
+    <div
+      className="col-6"
+    >
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          {
+            "max": 168,
+            "min": 0,
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText={
+              <div>
+                <p>
+                  The minimum number of hours per week the learner should expect to spend on the course.
+                </p>
+              </div>
+            }
+            id="test-course.min_effort.label"
+            optional={false}
+            text="Minimum effort"
+          />
+        }
+        name="test-course.min_effort"
+        required={false}
+        type="number"
+      />
+    </div>
+    <div
+      className="col-6"
+    >
+      <Field
+        component={[Function]}
+        disabled={true}
+        extraInput={
+          {
+            "max": 168,
+            "min": 1,
+            "onInvalid": [Function],
+          }
+        }
+        label={
+          <FieldLabel
+            className=""
+            extraText=""
+            helpText={
+              <div>
+                <p>
+                  The maximum number of hours per week the learner should expect to spend on the course.
+                </p>
+              </div>
+            }
+            id="test-course.max_effort.label"
+            optional={false}
+            text="Maximum effort"
+          />
+        }
+        name="test-course.max_effort"
+        required={false}
+        type="number"
+      />
+    </div>
+  </div>
+  <Field
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    label={
+      <FieldLabel
+        className=""
+        extraText=""
+        helpText={
+          <div>
+            <p>
+              The estimated number of weeks the learner should expect to spend on the course, rounded to the nearest whole number.
+            </p>
+          </div>
+        }
+        id="test-course.weeks_to_complete.label"
+        optional={false}
+        text="Length"
+      />
+    }
+    name="test-course.weeks_to_complete"
+    required={false}
+    type="number"
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    label={
+      <FieldLabel
+        className=""
+        extraText=""
+        helpText=""
+        id={null}
+        optional={false}
+        text="Content language"
+      />
+    }
+    name="test-course.content_language"
+    options={
+      [
+        {
+          "label": "Arabic - United Arab Emirates",
+          "value": "ar-ae",
+        },
+      ]
+    }
+    required={false}
+    type="text"
+  />
+  <FieldLabel
+    className="mb-2"
+    extraText=""
+    helpText=""
+    id={null}
+    optional={false}
+    text="Transcript languages"
+  />
+  <FieldArray
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    languageOptions={
+      [
+        {
+          "label": "Arabic - United Arab Emirates",
+          "value": "ar-ae",
+        },
+      ]
+    }
+    name="test-course.transcript_languages"
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    label={
+      <FieldLabel
+        className=""
+        extraText=""
+        helpText={
+          <div>
+            <p>
+              If this Course Run will potentially be part of a Program, please set the expected program type here.
+            </p>
+          </div>
+        }
+        id="test-course.expected_program_type.label"
+        optional={true}
+        text="Expected Program Type"
+      />
+    }
+    name="test-course.expected_program_type"
+    type="text"
+  />
+  <Field
+    component={[Function]}
+    disabled={true}
+    extraInput={
+      {
+        "onInvalid": [Function],
+      }
+    }
+    label={
+      <FieldLabel
+        className=""
+        extraText=""
+        helpText={
+          <div>
+            <p>
+              If this Course Run will potentially be part of a Program, please set the expected program name here.
+            </p>
+          </div>
+        }
+        id="test-course.expected_program_name.label"
+        optional={true}
+        text="Expected Program Name"
+      />
+    }
+    name="test-course.expected_program_name"
+    type="text"
+  />
+  <div>
+    <FieldLabel
+      className="mb-2"
+      extraText=""
+      helpText={
+        <div>
+          <p>
+            Course embargo status for OFAC is managed internally, please contact support with questions.
+          </p>
+        </div>
+      }
+      id="ofac-notice-label"
+      optional={false}
+      text="Course Embargo (OFAC) Restriction text added to the FAQ section"
+    />
+    <div
+      className="mb-3"
+    >
+      No
+    </div>
+  </div>
+  <CourseRunButtonToolbar
+    className=""
+    disabled={true}
+    editable={false}
+    hasNonExemptChanges={false}
+    onSubmit={[Function]}
+    pristine={false}
+    status="review_by_internal"
+    submitting={false}
+  />
+</CustomCollapsible>
+`;
+
 exports[`Collapsible Course Run renders correctly when given a published course run 1`] = `
 <CustomCollapsible
   open={false}


### PR DESCRIPTION
This PR fixes the TinyMCE editor Language Selector `failed to find and set button ID in TinyMceLanguageSelectorPlugin after 3 attempts`. It adds a `0.1-sec` timeout to prevent TinyMCE from appearing immediately after the state change, as the editor reloads afterward, causing it to disappear and triggering the error above.

Error Reproduction Steps:

- Pull the code from the master branch.
- Create a new course run for any existing course.
- Add the relevant details and move the course to the review state. You should see the message `failed to find and set button ID in TinyMceLanguageSelectorPlugin after 3 attempts in the console log`.
- Checkout to this branch.
- Create a new course run for any existing course.
- You will no longer see this error in the console logs.
