### PR TITLE
temp: disable price edits if course has a published run

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -429,9 +429,11 @@ export class BaseEditCourseForm extends React.Component {
               disabled={disabled || !!entitlement.sku}
             />
             <PriceList
+              name="course_price_list"
               priceLabels={currentFormValues.type ? priceLabels[currentFormValues.type] : {}}
               extraInput={{ onInvalid: this.openCollapsible }}
-              disabled={disabled}
+              // temp: Disable price updates if one of runs is published.
+              disabled={courseStatuses.includes(PUBLISHED) || disabled}
               required={isSubmittingForReview}
             />
             <FieldLabel

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -255,6 +255,27 @@ describe('BaseEditCourseForm', () => {
     expect(disabledFields).toHaveLength(1);
   });
 
+  it('renders with price disabled if course has Published status among status list', () => {
+    const component = shallow(<BaseEditCourseForm
+      handleSubmit={() => null}
+      title={initialValuesFull.title}
+      initialValues={initialValuesFull}
+      currentFormValues={initialValuesFull}
+      number="Test101x"
+      entitlement={{ sku: 'ABC1234' }}
+      courseStatuses={[REVIEWED, PUBLISHED]}
+      courseInfo={courseInfo}
+      courseOptions={courseOptions}
+      courseRunOptions={courseRunOptions}
+      uuid={initialValuesFull.uuid}
+      type={initialValuesFull.type}
+      id="edit-course-form"
+    />);
+
+    const disabledFields = component.find({ name: 'course_price_list', disabled: true });
+    expect(disabledFields).toHaveLength(1);
+  });
+
   it('Check if watchers field is disabled after being reviewed', () => {
     const courseInfoWithCourseRunStatuses = {
       ...courseInfo,

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -336,6 +336,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={
           {
             "verified": "Verified",
@@ -2183,6 +2184,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={
           {
             "verified": "Verified",
@@ -4030,6 +4032,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={{}}
         required={false}
       />
@@ -5415,6 +5418,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={
           {
             "verified": "Verified",
@@ -7303,6 +7307,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={
           {
             "verified": "Verified",
@@ -9497,6 +9502,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={
           {
             "verified": "Verified",
@@ -11385,6 +11391,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={{}}
         required={false}
       />
@@ -12774,6 +12781,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
             "onInvalid": [Function],
           }
         }
+        name="course_price_list"
         priceLabels={{}}
         required={false}
       />

--- a/src/containers/MainApp/index.jsx
+++ b/src/containers/MainApp/index.jsx
@@ -20,13 +20,16 @@ import SitewideBanner from '../../components/SitewideBanner';
 const MainApp = () => (
   <div>
     <Header />
+    {/* Only display the banner if there is content to display. */}
+    {process.env.SITEWIDE_BANNER_CONTENT && (
     <SitewideBanner
-      message={process.env.SITEWIDE_BANNER_CONTENT || ''}
+      message={process.env.SITEWIDE_BANNER_CONTENT}
       type="warning"
       dismissible
       cookieName="publisherSiteWideBannerDismissed"
       cookieExpiryDays={30}
     />
+    )}
     <main>
       <Routes>
         <Route path="/course-runs/:courseRunKey" element={<CourseRunRedirectComponent />} />


### PR DESCRIPTION
### [PROD-4264](https://2u-internal.atlassian.net/browse/PROD-4264)

### Description

- Disable price edit if a course has published runs (this is temporary and will be removed)
- Only display sitewide banner if there is some content to display. The default banner without any content was always displaying and did not look alright.