### PR TITLE
feat: make level type and subjects field optional for masters courses

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -1007,7 +1007,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               options={levelTypeOptions}
               disabled={disabled}
-              required={isSubmittingForReview}
+              required={showMarketingFields && isSubmittingForReview}
             />
             <Field
               name="subjectPrimary"
@@ -1040,7 +1040,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               options={subjectOptions}
               disabled={disabled}
-              required={isSubmittingForReview}
+              required={showMarketingFields && isSubmittingForReview}
             />
             <Field
               name="subjectSecondary"

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -494,4 +494,33 @@ describe('BaseEditCourseForm', () => {
     />);
     expect(shallowToJson(component)).toMatchSnapshot();
   });
+
+  it('does not add required prop for level_type and subjectPrimary fields when not submitting for review', () => {
+    const initialValuesWithMasters = {
+      ...initialValuesFull,
+      type: '7b41992e-f268-4331-8ba9-72acb0880454',
+    };
+
+    const component = shallow(<BaseEditCourseForm
+      handleSubmit={() => null}
+      title="Test Course"
+      initialValues={{ title: initialValuesFull.title }}
+      currentFormValues={initialValuesWithMasters}
+      number="Test101x"
+      courseStatuses={[UNPUBLISHED]}
+      courseInfo={courseInfo}
+      courseOptions={courseOptions}
+      courseRunOptions={courseRunOptions}
+      uuid={initialValuesWithMasters.uuid}
+      type={initialValuesWithMasters.type}
+      isSubmittingForReview={false}
+      id="edit-course-form"
+    />);
+
+    const levelTypeField = component.find(Field).filterWhere(n => n.prop('name') === 'level_type');
+    const subjectPrimaryField = component.find(Field).filterWhere(n => n.prop('name') === 'subjectPrimary');
+
+    expect(levelTypeField.prop('required')).toBe(false);
+    expect(subjectPrimaryField.prop('required')).toBe(false);
+  });
 });


### PR DESCRIPTION
[PROD-3254](https://2u-internal.atlassian.net/browse/PROD-3254)
This PR puts Level Type and Primary Subject as non-marketable fields i.e. make them optional for masters courses (and all the non-marketable courses)