### PR TITLE
Update README: Convert to MD and mention Tutor install

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,13 @@ possibly configure and install it on their own.
 ## Getting Started
 
 This application requires an edx-platform instance for authentication. For local development
-   you will need to setup a local instance of the edX Docker Devstack
-    * https://github.com/openedx/devstack
+you should use [Tutor](https://docs.tutor.edly.io/), the community-supported Open edX development environment.
+
+See the [instructions on using the Tutor MFE plugin here](https://github.com/overhangio/tutor-mfe?tab=readme-ov-file#mfe-development).
+
+
+The edX Docker Devstack is now deprecated.
+    * https://github.com/openedx-unsupported/devstack
 
  You should be able to view it in a web browser at `localhost:18400`.
 
@@ -90,9 +95,8 @@ This application requires an edx-platform instance for authentication. For local
 
     ``git clone https://github.com/openedx/frontend-app-publisher.git``
 
-  2. Use node v18.x.
+  2. Use the version of Node specified in ``.nvmrc``
 
-    The current version of the micro-frontend build scripts support node 18.
     Using other major versions of node *may* work, but this is unsupported.  For
     convenience, this repository includes an .nvmrc file to help in setting the
     correct node version via `nvm <https://github.com/nvm-sh/nvm>`_.

--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ Please see `LICENSE <LICENSE>`_ for details.
 Contributing
 ============
 
-Contributions are very welcome.  Please read `How To Contribute`_ for details.
-
-.. _How To Contribute: https://openedx.org/r/how-to-contribute
+Contributions are very welcome.  Please read [How To Contribute](https://docs.openedx.org/en/latest/developers/references/developer_guide/process/index.html) for details.
 
 This project is currently accepting all types of contributions, bug fixes,
 security fixes, maintenance work, or new features.  However, please make sure
@@ -170,29 +168,25 @@ Getting Help
 If you're having trouble, we have discussion forums at
 https://discuss.openedx.org where you can connect with others in the community.
 
-Our real-time conversations are on Slack. You can request a `Slack
-invitation`_, then join our `community Slack workspace`_.  Because this is a
-frontend repository, the best place to discuss it would be in the `#wg-frontend
-channel`_.
+Our real-time conversations are on Slack. You can request a [Slack
+invitation](https://openedx.org/slack), then join our
+[community Slack workspace](https://openedx.slack.com/)  Because this is a
+frontend repository, the best place to discuss it would be in the
+[#wg-frontend channel](https://openedx.slack.com/archives/C04BM6YC7A6).
 
 For anything non-trivial, the best path is to open an issue in this repository
 with as many details about the issue you are facing as you can provide.
 
 https://github.com/openedx/frontend-app-publisher/issues
 
-For more information about these options, see the `Getting Help`_ page.
+For more information about these options, see the [Getting Help](https://openedx.org/community/connect) page.
 
-.. _Slack invitation: https://openedx.org/slack
-.. _community Slack workspace: https://openedx.slack.com/
-.. _#wg-frontend channel: https://openedx.slack.com/archives/C04BM6YC7A6
-.. _Getting Help: https://openedx.org/community/connect
 
  The Open edX Code of Conduct
 ============================
 
-All community members are expected to follow the `Open edX Code of Conduct`_.
+All community members are expected to follow the [Open edX Code of Conduct](https://openedx.org/code-of-conduct/).
 
-.. _Open edX Code of Conduct: https://openedx.org/code-of-conduct/
 
 Reporting Security Issues
 =========================


### PR DESCRIPTION
- **docs: Fully convert README to markdown** (it was half in MD and half in RST, changed to md to match the style of other fea- repos)
- **docs: Update README to point to Tutor**
