### PR TITLE
feat!: update tinymce-react to v6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-solid-svg-icons": "6.6.0",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@openedx/paragon": "^21.11.3",
-        "@tinymce/tinymce-react": "3.9.0",
+        "@tinymce/tinymce-react": "6.1.0",
         "classnames": "2.5.1",
         "core-js": "3.38.1",
         "fast-json-stable-stringify": "2.1.0",
@@ -3970,16 +3970,21 @@
       }
     },
     "node_modules/@tinymce/tinymce-react": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.9.0.tgz",
-      "integrity": "sha512-1DgMahuESQuGMvSpCabw2WrgfRQmPTuCOpThMB/aFJYSpGoLYe7kV4QJwMEWB1HXBfTV9ahG6yMNcP9PTfYk5A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-6.1.0.tgz",
+      "integrity": "sha512-K0MP3yYVKe8+etUwsg6zyRq+q9TGLaVf005WiBHiB8JZEomAwbBPERGunhU9uOqNQ5gJs8yVOPZ68Xcd1UHclA==",
       "dependencies": {
-        "prop-types": "^15.6.2",
-        "tinymce": "^5.6.2"
+        "prop-types": "^15.6.2"
       },
       "peerDependencies": {
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1"
+        "react": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0",
+        "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0",
+        "tinymce": "^7.0.0 || ^6.0.0 || ^5.5.1"
+      },
+      "peerDependenciesMeta": {
+        "tinymce": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-solid-svg-icons": "6.6.0",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@openedx/paragon": "^21.11.3",
-    "@tinymce/tinymce-react": "3.9.0",
+    "@tinymce/tinymce-react": "6.1.0",
     "classnames": "2.5.1",
     "core-js": "3.38.1",
     "fast-json-stable-stringify": "2.1.0",

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
     className=""
   >
     <Editor
-      cloudChannel="5"
+      cloudChannel="7"
       disabled={false}
       init={
         {
@@ -37,10 +37,11 @@ exports[`RichEditor shows a rich text editor and an error 1`] = `
           "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
-      initialValue={null}
       onChange={[Function]}
+      onEditorChange={[Function]}
       onInit={[Function]}
       onKeyUp={[Function]}
+      value={null}
     />
     <span>
       Recommended character limit (including spaces) is
@@ -68,7 +69,7 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
     className=""
   >
     <Editor
-      cloudChannel="5"
+      cloudChannel="7"
       disabled={false}
       init={
         {
@@ -89,10 +90,11 @@ exports[`RichEditor shows a rich text editor with default text value 1`] = `
           "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
-      initialValue="<p>Prior text<p>"
       onChange={[Function]}
+      onEditorChange={[Function]}
       onInit={[Function]}
       onKeyUp={[Function]}
+      value="<p>Prior text<p>"
     />
     <span>
       Recommended character limit (including spaces) is
@@ -118,7 +120,7 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
     className=""
   >
     <Editor
-      cloudChannel="5"
+      cloudChannel="7"
       disabled={false}
       init={
         {
@@ -139,10 +141,11 @@ exports[`RichEditor shows a rich text editor with no default text value 1`] = `
           "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
-      initialValue={null}
       onChange={[Function]}
+      onEditorChange={[Function]}
       onInit={[Function]}
       onKeyUp={[Function]}
+      value={null}
     />
     <span>
       Recommended character limit (including spaces) is
@@ -170,7 +173,7 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
     className=""
   >
     <Editor
-      cloudChannel="5"
+      cloudChannel="7"
       disabled={false}
       init={
         {
@@ -191,10 +194,11 @@ exports[`RichEditor shows a rich text editor with no maxChars 1`] = `
           "toolbar": "undo redo | bold italic underline | bullist numlist | link | language | ltr rtl",
         }
       }
-      initialValue="<p>Prior text<p>"
       onChange={[Function]}
+      onEditorChange={[Function]}
       onInit={[Function]}
       onKeyUp={[Function]}
+      value="<p>Prior text<p>"
     />
   </div>
 </div>

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
 import { Editor } from '@tinymce/tinymce-react';
 import 'tinymce/tinymce.min';
 import 'tinymce/icons/default';
@@ -21,9 +20,20 @@ class RichEditor extends React.Component {
     super(props);
     this.state = {
       charCount: 0,
+      value: props.input.value,
     };
     this.initCharCount = this.initCharCount.bind(this);
     this.updateCharCount = this.updateCharCount.bind(this);
+    this.handleEditorChange = this.handleEditorChange.bind(this);
+    this.handleOnChange = this.handleOnChange.bind(this);
+  }
+
+  handleEditorChange(newValue, editor) {
+    this.updateCharCount(editor);
+  }
+
+  handleOnChange(event, editor) {
+    this.updateCharCount(editor);
   }
 
   initCharCount(event, editor) {
@@ -33,12 +43,16 @@ class RichEditor extends React.Component {
     });
   }
 
-  updateCharCount(event, editor) {
+  updateCharCount(editor) {
     const content = editor.getContent({ format: 'text' });
+    const htmlContent = editor.getContent();
+
     this.setState({
       charCount: content.length,
+      value: htmlContent,
     });
-    const htmlContent = editor.getContent();
+
+    // propagate the changes to redux form field
     this.props.input.onChange(htmlContent);
   }
 
@@ -48,7 +62,6 @@ class RichEditor extends React.Component {
       id,
       label,
       input: {
-        value,
         name,
       },
       meta: {
@@ -85,7 +98,7 @@ class RichEditor extends React.Component {
         */}
         <div aria-labelledby={id} className={classNames({ 'disabled-rich-text': disabled })}>
           <Editor
-            initialValue={value}
+            value={this.state.value}
             init={{
               branding: false,
               menubar: false,
@@ -103,8 +116,9 @@ class RichEditor extends React.Component {
               content_style: contentStyle,
               default_link_target: '_blank',
             }}
-            onChange={this.updateCharCount}
-            onKeyUp={this.updateCharCount}
+            onChange={this.handleOnChange}
+            onEditorChange={this.handleEditorChange}
+            onKeyUp={this.handleOnChange}
             onInit={this.initCharCount}
             disabled={disabled}
           />


### PR DESCRIPTION
### [PROD-4362](https://2u-internal.atlassian.net/browse/PROD-4362)

### Description
The PR updates tinymce-react to v6.1.0. In doing this change, there have been some changes in how the editor content state is managed. 

- Instead of using initialValue, [value](https://www.tiny.cloud/docs/tinymce/latest/react-ref/#value) prop is used to manage the editor content. While both initial value and value can be used together, it did not cause any impact on the functionality of the editor. 
- Make component controlled. Previously, the component was using [OnChange](https://www.tiny.cloud/docs/tinymce/latest/react-ref/#event-binding) to handle character count change and propagate content to redux form field. This did not work correctly when initialValue was changed to value. The editor state needed to be changed. For this purpose, alongside OnChange, [OnEditorChange](https://www.tiny.cloud/docs/tinymce/latest/react-ref/#oneditorchange) prop has been added. This prop is tinymce-react specific and should be used when using editor as controlled.