### PR TITLE
Skip char count update if editor not dirty

### DIFF
--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -41,7 +41,11 @@ class RichEditor extends React.Component {
   }
 
   handleEditorChange(newValue, editor) {
-    this.updateCharCount(editor);
+    // Only update if the editor is actually dirty (user made changes)
+    // This prevents Redux Form from being marked dirty due to TinyMCE normalization
+    if (editor.isDirty()) {
+      this.updateCharCount(editor);
+    }
   }
 
   handleOnChange(event, editor) {


### PR DESCRIPTION
### [PROD-4373](https://2u-internal.atlassian.net/browse/PROD-4373)

Only update if the editor is actually dirty (user made changes)
This prevents Redux Form from being marked dirty due to TinyMCE normalization