### PR TITLE
fix: create course run form in strict mode

### DIFF
--- a/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
@@ -222,12 +222,12 @@ BaseCreateCourseRunForm.propTypes = {
 
 const CreateCourseRunForm = compose(
   connect((state, props) => ({
-    // Give form a unique id so that values from one course form don't overwrite others
+    // Give form a unique id so that values from one form don't overwrite others
     form: props.id,
   })),
   reduxForm({
     destroyOnUnmount: false,
     enableReinitialize: true,
-  })
+  }),
 )(BaseCreateCourseRunForm);
 export { BaseCreateCourseRunForm, CreateCourseRunForm };

--- a/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunForm.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 
 import ButtonToolbar from '../ButtonToolbar';
 import FieldLabel from '../FieldLabel';
@@ -218,7 +220,14 @@ BaseCreateCourseRunForm.propTypes = {
   canSetRunKey: PropTypes.bool.isRequired,
 };
 
-const CreateCourseRunForm = reduxForm({
-  form: 'create-course-run-form',
-})(BaseCreateCourseRunForm);
+const CreateCourseRunForm = compose(
+  connect((state, props) => ({
+    // Give form a unique id so that values from one course form don't overwrite others
+    form: props.id,
+  })),
+  reduxForm({
+    destroyOnUnmount: false,
+    enableReinitialize: true,
+  })
+)(BaseCreateCourseRunForm);
 export { BaseCreateCourseRunForm, CreateCourseRunForm };

--- a/src/components/CreateCourseRunPage/index.jsx
+++ b/src/components/CreateCourseRunPage/index.jsx
@@ -162,6 +162,7 @@ class CreateCourseRunPage extends React.Component {
           && (
             <div>
               <CreateCourseRunForm
+                id={`create-course-run-form-${uuid}`}
                 onSubmit={this.handleCourseCreate}
                 title={title}
                 uuid={uuid}

--- a/src/containers/CreateCourseRun/index.jsx
+++ b/src/containers/CreateCourseRun/index.jsx
@@ -15,7 +15,7 @@ const mapStateToProps = state => ({
   courseInfo: state.courseInfo,
   courseOptions: state.courseOptions,
   courseRunOptions: state.courseRunOptions,
-  formValues: getFormValues('create-course-run-form')(state),
+  formValues: getFormValues(`create-course-run-form-${state.courseInfo.data.uuid}`)(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
[PROD-4403](https://2u-internal.atlassian.net/browse/PROD-4403)
------------

ReduxForm "[loses](https://github.com/redux-form/redux-form/issues/4152)" initialValues when a form is unmounted and remounted. This is what react StrictMode aims to [emulate](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development) (among other things), hence causing the `CreateCourseRunForm` to break in StrictMode. 

As a workaround, we set the `destroyOnUnmount` setting to `false`, which prevents redux-form from clearing the form redux state (which includes `initialValues`) on an unmount. Since we are not destroying the state on an unmount, just to be extra-safe, I have also changed the ids for the form based on the course being rerun, so that the states for separate forms(those belonging to different courses) use different keys.

The same practices are already being [followed](https://github.com/openedx/frontend-app-publisher/blob/master/src/components/EditCoursePage/EditCourseForm.jsx#L1409-L1413) by EditCourseForm.