### PR TITLE
fix: UI inconsistencies across all Publisher pages

### DIFF
--- a/src/components/BulkOperationDetailsPage/BulkOperationDetails.jsx
+++ b/src/components/BulkOperationDetailsPage/BulkOperationDetails.jsx
@@ -64,7 +64,6 @@ const BulkOperationDetails = ({ task }) => {
       setCsvHeaders(headers);
       setCsvRows(rows);
     } catch (error) {
-      console.error('Failed to preview CSV:', error);
       setCsvPreviewError(`Failed to preview CSV: ${error.message}`);
     }
   };
@@ -100,7 +99,7 @@ const BulkOperationDetails = ({ task }) => {
 
   return (
     <div className="container mt-2">
-      <h2 className="mb-4">Task Details</h2>
+      <h2 className="mb-2">Task Details</h2>
       <div className="bulk-op-details-table-container">
         <DataTable
           columns={taskInfoColumns}
@@ -112,7 +111,7 @@ const BulkOperationDetails = ({ task }) => {
       <Stack direction="horizontal" gap={3} className="mb-4 mt-4">
         <a
           href={task.csv_file}
-          className="btn btn-outline-primary"
+          className="btn btn-outline-primary download"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -120,6 +119,7 @@ const BulkOperationDetails = ({ task }) => {
         </a>
         <Button
           variant="primary"
+          className="PreviewCSV"
           onClick={() => {
             handlePreviewCSV();
             open();

--- a/src/components/BulkOperationDetailsPage/index.jsx
+++ b/src/components/BulkOperationDetailsPage/index.jsx
@@ -17,7 +17,6 @@ const BulkOperationTaskDetailsPage = () => {
         setTask(response.data);
       })
       .catch((error) => {
-        console.error('Error fetching bulk operation details:', error);
         setError(error.message);
       });
   }, [taskId]);

--- a/src/components/BulkOperationDetailsPage/styles.scss
+++ b/src/components/BulkOperationDetailsPage/styles.scss
@@ -57,3 +57,16 @@ $cell-widths: 220px;
     display: none;
    }
 }
+
+.download {
+  border-radius: 0;
+  font-weight: bold;
+  border: 1px solid #ddd;
+  font-size: 16px;
+}
+
+.preview_csv {
+  border-radius: 0;
+  font-weight: 550;
+  font-size: 16px;
+}

--- a/src/components/BulkOperations/BulkOperations.scss
+++ b/src/components/BulkOperations/BulkOperations.scss
@@ -31,3 +31,13 @@
         display: none;
     }
 }
+.custom-selectmenu button {
+  border: 1px solid #ddd !important;
+  box-shadow: none !important;
+  font-weight: bold;
+}
+
+.custom-selectmenu button:focus {
+  outline: none;
+  box-shadow: 0 0 0 1px #ddd !important;
+}

--- a/src/components/BulkOperations/index.jsx
+++ b/src/components/BulkOperations/index.jsx
@@ -129,7 +129,7 @@ const BulkOperations = () => {
       {!isLoading && (
       <div className="mx-5 my-5">
         {getAlert()}
-        <SelectMenu className="mb-3" defaultMessage="Choose a Bulk Operation">
+        <SelectMenu className="mb-3 custom-selectmenu" defaultMessage="Choose a Bulk Operation">
           {
             Object.entries(availableOperations).map(([id, title]) => (
               <MenuItem actionid={id} key={id} defaultSelected={id === bulkOperationId} onClick={e => setBulkOperationId(e.currentTarget.getAttribute('actionid'))}>

--- a/src/components/CollaboratorPage/CollaboratorForm.jsx
+++ b/src/components/CollaboratorPage/CollaboratorForm.jsx
@@ -58,7 +58,7 @@ const BaseCollaboratorForm = ({
         />
         <ButtonToolbar>
           <Link
-            className="btn btn-outline-primary form-cancel-btn"
+            className="btn btn-outline-primary form-cancel-btn collaborator-form"
             to={referrer || '/'}
             disabled={formControlDisabled}
             onClick={cancelCollaboratorInfo}
@@ -67,6 +67,7 @@ const BaseCollaboratorForm = ({
           </Link>
           <ActionButton
             disabled={formControlDisabled}
+            className="collaborator-form"
             labels={isCreateForm ? {
               default: 'Create',
               pending: 'Creating',

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>
@@ -3275,7 +3275,7 @@ exports[`Collapsible Course Run renders correctly restriction type field for ext
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>
@@ -6529,7 +6529,7 @@ exports[`Collapsible Course Run renders correctly variant_id field for external 
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>
@@ -9783,7 +9783,7 @@ exports[`Collapsible Course Run renders correctly when given a published course 
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-success"
+            class="ml-2 badge badge-success custom-pill"
           >
             Published
           </span>
@@ -12788,7 +12788,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
                 Course run starting on Jan 01, 2000 - Self Paced
               </span>
               <span
-                class="ml-2 badge badge-warning"
+                class="ml-2 badge badge-warning custom-pill"
               >
                 Unsubmitted
               </span>
@@ -15800,7 +15800,7 @@ exports[`Collapsible Course Run renders correctly when given an unpublished cour
               Course run starting on Jan 01, 2000 - Self Paced
             </span>
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -18850,7 +18850,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review 1`]
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>
@@ -21848,7 +21848,7 @@ exports[`Collapsible Course Run renders correctly when submitting for review and
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-success"
+            class="ml-2 badge badge-success custom-pill"
           >
             Published
           </span>
@@ -24844,7 +24844,7 @@ exports[`Collapsible Course Run renders correctly with a course run type 1`] = `
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>
@@ -27857,7 +27857,7 @@ exports[`Collapsible Course Run renders correctly with external key field enable
             Course run starting on Jan 01, 2000 - Self Paced
           </span>
           <span
-            class="ml-2 badge badge-warning"
+            class="ml-2 badge badge-warning custom-pill"
           >
             Unsubmitted
           </span>

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -4723,7 +4723,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -9407,7 +9407,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -12077,7 +12077,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -16758,7 +16758,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -22960,7 +22960,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -27641,7 +27641,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -30311,7 +30311,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`BaseEditCourseForm override slug format when IS_NEW_SLUG_FORMAT_ENABLED
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -4306,7 +4306,7 @@ exports[`BaseEditCourseForm renders correctly when submitting for review 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -8573,7 +8573,7 @@ exports[`BaseEditCourseForm renders html correctly while fetching collaborator o
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -11243,7 +11243,7 @@ exports[`BaseEditCourseForm renders html correctly while submitting 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -15507,7 +15507,7 @@ exports[`BaseEditCourseForm renders html correctly with administrator being true
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -21288,7 +21288,7 @@ exports[`BaseEditCourseForm renders html correctly with all data present 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -25552,7 +25552,7 @@ exports[`BaseEditCourseForm renders html correctly with minimal data 1`] = `
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -28222,7 +28222,7 @@ exports[`BaseEditCourseForm renders html correctly with skills data when skills 
           >
             Course: Test Title
             <span
-              class="ml-2 badge badge-warning"
+              class="ml-2 badge badge-warning custom-pill"
             >
               Unsubmitted
             </span>
@@ -31106,7 +31106,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -33794,7 +33794,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -33817,7 +33817,7 @@ exports[`EditCoursePage renders html correctly 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -33987,7 +33987,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -36675,7 +36675,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -36698,7 +36698,7 @@ exports[`EditCoursePage renders page correctly with courseInfo 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -36831,7 +36831,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -39519,7 +39519,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -39542,7 +39542,7 @@ exports[`EditCoursePage renders page correctly with courseInfo and courseOptions
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -39675,7 +39675,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -42379,7 +42379,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -42402,7 +42402,7 @@ exports[`EditCoursePage renders page correctly with courseInfo error 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -42535,7 +42535,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -45223,7 +45223,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -45246,7 +45246,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -45379,7 +45379,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -48087,7 +48087,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -48110,7 +48110,7 @@ exports[`EditCoursePage renders page correctly with courseInfo, courseOptions, a
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -48272,7 +48272,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -50960,7 +50960,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -50983,7 +50983,7 @@ exports[`EditCoursePage renders page correctly with courseOptions error 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -51116,7 +51116,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -53804,7 +53804,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -53827,7 +53827,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions 1`] = `
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>
@@ -53960,7 +53960,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
                 >
                   Course: Test title
                   <span
-                    class="ml-2 badge badge-success"
+                    class="ml-2 badge badge-success custom-pill"
                   >
                     Published
                   </span>
@@ -56664,7 +56664,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Users
             </div>
@@ -56687,7 +56687,7 @@ exports[`EditCoursePage renders page correctly with courseRunOptions error 1`] =
             class="card mb-3"
           >
             <div
-              class="card-header bg-primary-700 text-white"
+              class="card-header bg-primary-700 text-white p-3"
             >
               Comments
             </div>

--- a/src/components/Pill/__snapshots__/Pill.test.jsx.snap
+++ b/src/components/Pill/__snapshots__/Pill.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Pill renders with a single status 1`] = `
 <div>
   <span
-    class="ml-2 badge badge-light"
+    class="ml-2 badge badge-light custom-pill"
   >
     In review
   </span>
@@ -22,7 +22,7 @@ exports[`Pill renders with invalid statuses 1`] = `<div />`;
 exports[`Pill renders with multiple statuses 1`] = `
 <div>
   <span
-    class="ml-2 badge badge-light"
+    class="ml-2 badge badge-light custom-pill"
   >
     In review
   </span>
@@ -34,7 +34,7 @@ exports[`Pill renders with multiple statuses 1`] = `
     />
   </span>
   <span
-    class="ml-2 badge badge-success"
+    class="ml-2 badge badge-success custom-pill"
   >
     Published
   </span>

--- a/src/components/Pill/index.jsx
+++ b/src/components/Pill/index.jsx
@@ -24,26 +24,26 @@ const Pill = ({ statuses }) => {
       case ARCHIVED:
         pills.push({
           text: formatMessage(messages.statusArchived),
-          className: 'badge badge-secondary',
+          className: 'badge badge-secondary custom-pill',
         });
         break;
       case UNPUBLISHED:
         pills.push({
           text: formatMessage(messages.statusUnsubmitted),
-          className: 'badge badge-warning',
+          className: 'badge badge-warning custom-pill',
         });
         break;
       case REVIEWED:
         pills.push({
           text: formatMessage(messages.statusScheduled),
-          className: 'badge badge-primary',
+          className: 'badge badge-primary custom-pill',
         });
         break;
       case REVIEW_BY_LEGAL:
       case REVIEW_BY_INTERNAL:
         pills.push({
           text: formatMessage(messages.statusInReview),
-          className: 'badge badge-light',
+          className: 'badge badge-light custom-pill',
         });
         pills.push({
           text: <i className="fa fa-lock" />,
@@ -52,7 +52,7 @@ const Pill = ({ statuses }) => {
       case PUBLISHED:
         pills.push({
           text: formatMessage(messages.statusPublished),
-          className: 'badge badge-success',
+          className: 'badge badge-success custom-pill',
         });
         break;
       default:

--- a/src/components/SidePanes/Pane.jsx
+++ b/src/components/SidePanes/Pane.jsx
@@ -5,7 +5,7 @@ import { InfoOutline } from '@openedx/paragon/icons';
 
 const Pane = (props) => (
   <div data-testid={props.dataTestId} className="card mb-3">
-    <div className="card-header bg-primary-700 text-white">
+    <div className="card-header bg-primary-700 text-white p-3">
       {props.title}
       {props.info && (
       <OverlayTrigger

--- a/src/components/SitewideBanner/index.jsx
+++ b/src/components/SitewideBanner/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
+import PropTypes from 'prop-types';
 import {
   Alert, Container,
 } from 'react-bootstrap';
@@ -32,7 +32,7 @@ const SitewideBanner = ({
         className="mb-4"
       >
         <Container>
-          <div dangerouslySetInnerHTML={{ __html: message }} />
+          {message}
         </Container>
       </Alert>
     );

--- a/src/components/StafferPage/AreasOfExpertise.jsx
+++ b/src/components/StafferPage/AreasOfExpertise.jsx
@@ -50,7 +50,7 @@ class AreasOfExpertise extends React.Component {
         <button
           type="button"
           data-testid="js-add-button"
-          className="btn btn-outline-primary js-add-button mt-2"
+          className="btn js-add-button mt-2 social_area"
           onClick={() => fields.push({})}
         >
           Add area of expertise

--- a/src/components/StafferPage/SocialLinks.jsx
+++ b/src/components/StafferPage/SocialLinks.jsx
@@ -78,7 +78,7 @@ class SocialLinks extends React.Component {
         <button
           type="button"
           data-testid="js-add-button"
-          className="btn btn-outline-primary js-add-button mt-2"
+          className="btn js-add-button mt-2 social_area"
           onClick={() => fields.push({})}
         >
           Add social link

--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -13,6 +13,7 @@ import RichEditor from '../RichEditor';
 import FieldLabel from '../FieldLabel';
 import ButtonToolbar from '../ButtonToolbar';
 import { basicValidate, handleStafferOrCreateFormFail } from '../../utils/validation';
+import './StafferForm.scss';
 
 const BaseStafferForm = ({
   handleSubmit,
@@ -138,9 +139,9 @@ const BaseStafferForm = ({
           name="areas_of_expertise"
           component={AreasOfExpertise}
         />
-        <ButtonToolbar>
+        <ButtonToolbar className="button-toolbar">
           <Link
-            className="btn btn-outline-primary form-cancel-btn"
+            className="btn form-cancel-btn cancel_button"
             to={referrer || '/'}
             disabled={formControlDisabled}
             onClick={cancelStafferInfo}
@@ -149,6 +150,7 @@ const BaseStafferForm = ({
           </Link>
           <ActionButton
             disabled={formControlDisabled}
+            className="create_button"
             labels={isCreateForm ? {
               default: 'Create',
               pending: 'Creating',

--- a/src/components/StafferPage/StafferForm.scss
+++ b/src/components/StafferPage/StafferForm.scss
@@ -29,3 +29,24 @@
     }
   }
 }
+
+.social_area {
+  border: 1px solid #ddd;
+  font-size: 16px;
+  font-weight: 550;
+  color: #001747;
+}
+
+.cancel_button {
+  border: 1px solid #ddd;
+  font-weight: 550;
+  font-size: 16px;
+  color: #001747;
+  border-radius: 0;
+}
+
+.create_button {
+  background-color: #7C7E83;
+  font-weight: bold;
+  border-radius: 0;
+}

--- a/src/components/StafferPage/__snapshots__/AreasOfExpertise.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/AreasOfExpertise.test.jsx.snap
@@ -78,7 +78,7 @@ exports[`Areas Of Expertise renders correctly when given fields 1`] = `
       </li>
     </ul>
     <button
-      class="btn btn-outline-primary js-add-button mt-2"
+      class="btn js-add-button mt-2 social_area"
       data-testid="js-add-button"
       type="button"
     >
@@ -97,7 +97,7 @@ exports[`Areas Of Expertise renders correctly with no fields 1`] = `
       class="list-group p-0 m-0 container-fluid"
     />
     <button
-      class="btn btn-outline-primary js-add-button mt-2"
+      class="btn js-add-button mt-2 social_area"
       data-testid="js-add-button"
       type="button"
     >

--- a/src/components/StafferPage/__snapshots__/SocialLinks.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/SocialLinks.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`Social links renders correctly when given fields 1`] = `
       class="list-group p-0 m-0 container-fluid"
     />
     <button
-      class="btn btn-outline-primary js-add-button mt-2"
+      class="btn js-add-button mt-2 social_area"
       data-testid="js-add-button"
       type="button"
     >
@@ -28,7 +28,7 @@ exports[`Social links renders correctly with no fields 1`] = `
       class="list-group p-0 m-0 container-fluid"
     />
     <button
-      class="btn btn-outline-primary js-add-button mt-2"
+      class="btn js-add-button mt-2 social_area"
       data-testid="js-add-button"
       type="button"
     >

--- a/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
@@ -1078,7 +1078,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -1110,7 +1110,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -1118,7 +1118,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
         </button>
       </div>
       <div
-        class="btn-toolbar justify-content-end"
+        class="btn-toolbar justify-content-end button-toolbar"
         role="toolbar"
       >
         <div
@@ -1126,7 +1126,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
           role="group"
         >
           <a
-            class="btn btn-outline-primary form-cancel-btn"
+            class="btn form-cancel-btn cancel_button"
             disabled=""
             href="/courses/00000000-0000-0000-0000-000000000000"
           >
@@ -1140,7 +1140,7 @@ exports[`StafferForm renders correctly when sent from the edit course page 1`] =
           <button
             aria-disabled="false"
             aria-live="assertive"
-            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
             disabled=""
             type="submit"
           >
@@ -2237,7 +2237,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -2269,7 +2269,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -2277,7 +2277,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
         </button>
       </div>
       <div
-        class="btn-toolbar justify-content-end"
+        class="btn-toolbar justify-content-end button-toolbar"
         role="toolbar"
       >
         <div
@@ -2285,7 +2285,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
           role="group"
         >
           <a
-            class="btn btn-outline-primary form-cancel-btn"
+            class="btn form-cancel-btn cancel_button"
             disabled=""
             href="/"
           >
@@ -2299,7 +2299,7 @@ exports[`StafferForm renders correctly with staffer info 1`] = `
           <button
             aria-disabled="false"
             aria-live="assertive"
-            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
             disabled=""
             type="submit"
           >
@@ -3396,7 +3396,7 @@ exports[`StafferForm renders html correctly 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -3428,7 +3428,7 @@ exports[`StafferForm renders html correctly 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -3436,7 +3436,7 @@ exports[`StafferForm renders html correctly 1`] = `
         </button>
       </div>
       <div
-        class="btn-toolbar justify-content-end"
+        class="btn-toolbar justify-content-end button-toolbar"
         role="toolbar"
       >
         <div
@@ -3444,7 +3444,7 @@ exports[`StafferForm renders html correctly 1`] = `
           role="group"
         >
           <a
-            class="btn btn-outline-primary form-cancel-btn"
+            class="btn form-cancel-btn cancel_button"
             disabled=""
             href="/"
           >
@@ -3458,7 +3458,7 @@ exports[`StafferForm renders html correctly 1`] = `
           <button
             aria-disabled="false"
             aria-live="assertive"
-            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
             disabled=""
             type="submit"
           >
@@ -4555,7 +4555,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -4587,7 +4587,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -4595,7 +4595,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
         </button>
       </div>
       <div
-        class="btn-toolbar justify-content-end"
+        class="btn-toolbar justify-content-end button-toolbar"
         role="toolbar"
       >
         <div
@@ -4603,7 +4603,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
           role="group"
         >
           <a
-            class="btn btn-outline-primary form-cancel-btn"
+            class="btn form-cancel-btn cancel_button"
             disabled=""
             href="/"
           >
@@ -4617,7 +4617,7 @@ exports[`StafferForm renders html correctly when creating 1`] = `
           <button
             aria-disabled="true"
             aria-live="assertive"
-            class="pgn__stateful-btn pgn__stateful-btn-state-pending btn form-submit-btn disabled btn btn-primary"
+            class="pgn__stateful-btn pgn__stateful-btn-state-pending btn form-submit-btn create_button disabled btn btn-primary"
             disabled=""
             type="submit"
           >
@@ -5737,7 +5737,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -5769,7 +5769,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
           class="list-group p-0 m-0 container-fluid"
         />
         <button
-          class="btn btn-outline-primary js-add-button mt-2"
+          class="btn js-add-button mt-2 social_area"
           data-testid="js-add-button"
           type="button"
         >
@@ -5777,7 +5777,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
         </button>
       </div>
       <div
-        class="btn-toolbar justify-content-end"
+        class="btn-toolbar justify-content-end button-toolbar"
         role="toolbar"
       >
         <div
@@ -5785,7 +5785,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
           role="group"
         >
           <a
-            class="btn btn-outline-primary form-cancel-btn"
+            class="btn form-cancel-btn cancel_button"
             disabled=""
             href="/"
           >
@@ -5799,7 +5799,7 @@ exports[`StafferForm renders html correctly when submitting 1`] = `
           <button
             aria-disabled="false"
             aria-live="assertive"
-            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+            class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
             disabled=""
             type="submit"
           >

--- a/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
@@ -1095,7 +1095,7 @@ exports[`StafferPage renders html correctly 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -1127,7 +1127,7 @@ exports[`StafferPage renders html correctly 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -1135,7 +1135,7 @@ exports[`StafferPage renders html correctly 1`] = `
                   </button>
                 </div>
                 <div
-                  class="btn-toolbar justify-content-end"
+                  class="btn-toolbar justify-content-end button-toolbar"
                   role="toolbar"
                 >
                   <div
@@ -1143,7 +1143,7 @@ exports[`StafferPage renders html correctly 1`] = `
                     role="group"
                   >
                     <a
-                      class="btn btn-outline-primary form-cancel-btn"
+                      class="btn form-cancel-btn cancel_button"
                       disabled=""
                       href="/"
                     >
@@ -1157,7 +1157,7 @@ exports[`StafferPage renders html correctly 1`] = `
                     <button
                       aria-disabled="false"
                       aria-live="assertive"
-                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
                       disabled=""
                       type="submit"
                     >
@@ -2304,7 +2304,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -2336,7 +2336,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -2344,7 +2344,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                   </button>
                 </div>
                 <div
-                  class="btn-toolbar justify-content-end"
+                  class="btn-toolbar justify-content-end button-toolbar"
                   role="toolbar"
                 >
                   <div
@@ -2352,7 +2352,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                     role="group"
                   >
                     <a
-                      class="btn btn-outline-primary form-cancel-btn"
+                      class="btn form-cancel-btn cancel_button"
                       disabled=""
                       href="/course/11111111-1111-1111-111111111111"
                     >
@@ -2366,7 +2366,7 @@ exports[`StafferPage renders html correctly when given a referrer 1`] = `
                     <button
                       aria-disabled="false"
                       aria-live="assertive"
-                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
                       disabled=""
                       type="submit"
                     >
@@ -3485,7 +3485,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -3517,7 +3517,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -3525,7 +3525,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                   </button>
                 </div>
                 <div
-                  class="btn-toolbar justify-content-end"
+                  class="btn-toolbar justify-content-end button-toolbar"
                   role="toolbar"
                 >
                   <div
@@ -3533,7 +3533,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                     role="group"
                   >
                     <a
-                      class="btn btn-outline-primary form-cancel-btn"
+                      class="btn form-cancel-btn cancel_button"
                       disabled=""
                       href="/"
                     >
@@ -3547,7 +3547,7 @@ exports[`StafferPage renders page correctly while creating 1`] = `
                     <button
                       aria-disabled="true"
                       aria-live="assertive"
-                      class="pgn__stateful-btn pgn__stateful-btn-state-pending btn form-submit-btn disabled btn btn-primary"
+                      class="pgn__stateful-btn pgn__stateful-btn-state-pending btn form-submit-btn create_button disabled btn btn-primary"
                       disabled=""
                       type="submit"
                     >
@@ -4756,7 +4756,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -4788,7 +4788,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                     class="list-group p-0 m-0 container-fluid"
                   />
                   <button
-                    class="btn btn-outline-primary js-add-button mt-2"
+                    class="btn js-add-button mt-2 social_area"
                     data-testid="js-add-button"
                     type="button"
                   >
@@ -4796,7 +4796,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                   </button>
                 </div>
                 <div
-                  class="btn-toolbar justify-content-end"
+                  class="btn-toolbar justify-content-end button-toolbar"
                   role="toolbar"
                 >
                   <div
@@ -4804,7 +4804,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                     role="group"
                   >
                     <a
-                      class="btn btn-outline-primary form-cancel-btn"
+                      class="btn form-cancel-btn cancel_button"
                       disabled=""
                       href="/"
                     >
@@ -4818,7 +4818,7 @@ exports[`StafferPage renders page correctly with staffer info error 1`] = `
                     <button
                       aria-disabled="false"
                       aria-live="assertive"
-                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn btn btn-primary"
+                      class="pgn__stateful-btn pgn__stateful-btn-state-default btn form-submit-btn create_button btn btn-primary"
                       disabled=""
                       type="submit"
                     >

--- a/src/sass/App.scss
+++ b/src/sass/App.scss
@@ -15,3 +15,18 @@
 ::-webkit-search-cancel-button {
   display: none;
 }
+
+.custom-pill {
+  width: auto;
+  height: auto;
+  text-align: center;
+  line-height: 25px;
+  font-size: 12px;
+}
+
+.collaborator-form {
+  font-size: 16px;
+  font-weight: 550;
+  color:#001747;
+  border-radius:0;
+}


### PR DESCRIPTION
This PR fixes UI inconsistencies across all Publisher pages to align with updated design tokens introduced platform-wide.

ticket for this - https://2u-internal.atlassian.net/browse/PROD-4404

Key Changes:

1.Main Page: Unified pill badge styles for consistent size, font, and alignment.

Before
<img width="1280" height="760" alt="Coursespage" src="https://github.com/user-attachments/assets/c050712a-fc1b-4102-9eea-71b307e74dc7" />



After
<img width="1277" height="600" alt="image" src="https://github.com/user-attachments/assets/c335c9ed-bc26-4a07-b9b6-77dec911c801" />


2.Course Details Page: Standardized side pane header styling and icon sizing.
Before
<img width="1280" height="760" alt="Course details page" src="https://github.com/user-attachments/assets/f5535938-2ec3-4e64-9ebf-ee9479f502d6" />


After
<img width="1269" height="634" alt="image" src="https://github.com/user-attachments/assets/7583ce8c-0fc0-4b9c-9873-d13614465ddd" />

3.New Staff Page: Applied consistent styles to all buttons (font, color, border, radius).
Before
<img width="1280" height="760" alt="New Instrutor" src="https://github.com/user-attachments/assets/43ee2065-5df5-4d9d-aa8e-26d44825f668" />

<img width="1280" height="760" alt="Newinstrutor2" src="https://github.com/user-attachments/assets/ee111cd1-d5c1-45f1-9a00-c6f64a93e167" />

After
<img width="1270" height="620" alt="image" src="https://github.com/user-attachments/assets/7d814076-1a89-4ee8-951d-eaf8bc9fc3af" />

<img width="1274" height="639" alt="image" src="https://github.com/user-attachments/assets/23ab2366-2f2d-4d47-8885-7f7cf3ba6fea" />


4.New Collaborator Page: Aligned cancel and create button styles with updated tokens.
Before
<img width="1280" height="760" alt="collobaratorpage" src="https://github.com/user-attachments/assets/05d56ad3-2c42-4d86-aae1-5fee53756317" />


After
<img width="1269" height="583" alt="image" src="https://github.com/user-attachments/assets/6312aee3-0061-412c-9d7d-29736ed71b9d" />

5.Bulk Operations Page: Customized with consistent border, font, and focus styles.
Before
<img width="1280" height="760" alt="Bulkoperational Page" src="https://github.com/user-attachments/assets/6cc8fada-6879-40c3-9e21-f0cdeff957cb" />


After
<img width="1269" height="596" alt="image" src="https://github.com/user-attachments/assets/05454394-f4ac-45da-8c11-65a1f6b94fdc" />

6.Bulk Operation Details Page: Standardized button styles for CSV actions (download/preview).
Before
<img width="1635" height="912" alt="image-20250630-060738 (2)" src="https://github.com/user-attachments/assets/15dcb5c7-b6b9-41f9-bdc0-00f5a6bb0c69" />

After
<img width="1267" height="587" alt="image" src="https://github.com/user-attachments/assets/c3166ac4-8785-4761-84d0-3b1729708928" />
